### PR TITLE
Off-Screen Overlay Support

### DIFF
--- a/Assets/Resources/Prefabs/Cameras.prefab
+++ b/Assets/Resources/Prefabs/Cameras.prefab
@@ -198,12 +198,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1850376182743320724}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 16, y: 9}
+  m_SizeDelta: {x: 24, y: 13.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &61794469810533299
 CanvasRenderer:
@@ -225,7 +225,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 2100000, guid: d5b6c66ebe6a79448978a7cb25df9202, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -251,7 +251,6 @@ GameObject:
   - component: {fileID: 1168123228960484818}
   - component: {fileID: 1574772130180899299}
   - component: {fileID: 974770566238864437}
-  - component: {fileID: 8162533768185923031}
   m_Layer: 31
   m_Name: GameView
   m_TagString: Untagged
@@ -266,12 +265,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2832441949350437337}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1850376182743320724}
-  m_RootOrder: 2
+  m_Father: {fileID: 9126116407185073410}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -298,11 +297,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 2100000, guid: d7c8faa192101444499e552f68b68e8c, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 0
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -313,24 +312,6 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
---- !u!114 &8162533768185923031
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2832441949350437337}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b8ee60af491978345bc197ed4e1316bc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MaskArea: {fileID: 9126116407185073410}
-  AlphaMask: {fileID: 0}
-  CutOff: 0
-  HardBlend: 0
-  FlipAlphaMask: 0
-  DontClipMaskScalingRect: 0
 --- !u!1 &3931965693507761463
 GameObject:
   m_ObjectHideFlags: 0
@@ -364,10 +345,10 @@ RectTransform:
   m_Father: {fileID: 1850376182743320724}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8799463193646473118
 CanvasRenderer:
@@ -524,7 +505,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.23529412, g: 0.23529412, b: 0.23529412, a: 0}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -550,7 +531,7 @@ Camera:
   m_TargetTexture: {fileID: 8400000, guid: da1c23fc8a9167c438d0d771189a6157, type: 2}
   m_TargetDisplay: 0
   m_TargetEye: 0
-  m_HDR: 1
+  m_HDR: 0
   m_AllowMSAA: 0
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
@@ -625,6 +606,7 @@ GameObject:
   - component: {fileID: 9126116407185073410}
   - component: {fileID: 9182755598382872870}
   - component: {fileID: 3596148951806340129}
+  - component: {fileID: 4765703529618674964}
   m_Layer: 31
   m_Name: LetterboxMask
   m_TagString: Untagged
@@ -642,7 +624,8 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1168123228960484818}
   m_Father: {fileID: 1850376182743320724}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -666,13 +649,13 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7252983913051326197}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 0
@@ -689,6 +672,20 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4765703529618674964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7252983913051326197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &8244570575520829750
 GameObject:
   m_ObjectHideFlags: 0
@@ -720,7 +717,6 @@ RectTransform:
   m_Children:
   - {fileID: 2525279720671331054}
   - {fileID: 9126116407185073410}
-  - {fileID: 1168123228960484818}
   - {fileID: 8313606602379655831}
   m_Father: {fileID: 6234653029009288364}
   m_RootOrder: 4
@@ -832,7 +828,7 @@ Camera:
   far clip plane: 1000
   field of view: 53.15
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 7.5
   m_Depth: 1
   m_CullingMask:
     serializedVersion: 2

--- a/Assets/Resources/Prefabs/Editor/SettingsMenu/GameSettings.prefab
+++ b/Assets/Resources/Prefabs/Editor/SettingsMenu/GameSettings.prefab
@@ -181,7 +181,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3848485333487225133}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -208,7 +208,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 2100000, guid: d5b6c66ebe6a79448978a7cb25df9202, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -1428,16 +1428,16 @@ RectTransform:
   m_GameObject: {fileID: 840567209939088497}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.6666667, y: 0.6666667, z: 1}
   m_Children: []
   m_Father: {fileID: 3848485333487225133}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 135}
   m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &291157345218112476
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1458,7 +1458,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 2100000, guid: d7c8faa192101444499e552f68b68e8c, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -2072,8 +2072,8 @@ MonoBehaviour:
   m_FillRect: {fileID: 8243922492801169335}
   m_HandleRect: {fileID: 6238887108514093961}
   m_Direction: 0
-  m_MinValue: -1
-  m_MaxValue: 1
+  m_MinValue: -1.5
+  m_MaxValue: 1.5
   m_WholeNumbers: 0
   m_Value: 0
   m_OnValueChanged:
@@ -2568,6 +2568,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6522129410091287029}
+  - {fileID: 9161835482758760361}
+  - {fileID: 7472294053606962503}
   - {fileID: 6182139952778885107}
   - {fileID: 6248411469160340147}
   m_Father: {fileID: 5761262922024577280}
@@ -9126,6 +9128,93 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5980277249143281484
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7472294053606962503}
+  - component: {fileID: 3562070850489374342}
+  - component: {fileID: 3183370803636418990}
+  - component: {fileID: 8834919911706332266}
+  m_Layer: 5
+  m_Name: ScreenBack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7472294053606962503
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5980277249143281484}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6666667, y: 0.6666667, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3848485333487225133}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 135}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3562070850489374342
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5980277249143281484}
+  m_CullTransparentMesh: 1
+--- !u!114 &3183370803636418990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5980277249143281484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!114 &8834919911706332266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5980277249143281484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 1
+  m_AspectRatio: 1.7777778
 --- !u!1 &6111764811185412714
 GameObject:
   m_ObjectHideFlags: 0
@@ -11074,6 +11163,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7150267262384080733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8823099424137248163}
+  - component: {fileID: 4970235650728955344}
+  - component: {fileID: 6790269430476297747}
+  m_Layer: 31
+  m_Name: LetterboxGlow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8823099424137248163
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7150267262384080733}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 90}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 9161835482758760361}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 460, y: 320}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4970235650728955344
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7150267262384080733}
+  m_CullTransparentMesh: 1
+--- !u!114 &6790269430476297747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7150267262384080733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 8be59c4bde4258c429ac39251f5f681b, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.3
 --- !u!1 &7273747442818994980
 GameObject:
   m_ObjectHideFlags: 0
@@ -11380,6 +11544,9 @@ MonoBehaviour:
   timingDispMinModeToggle: {fileID: 4906402620624022633}
   letterboxBgEnable: {fileID: 4396709347257482799}
   letterboxFxEnable: {fileID: 2017189606605254942}
+  LytEditBg: {fileID: 2373156634136147033}
+  LytEditBgAmbi: {fileID: 6790269430476297747}
+  LytEditBgAmbiGO: {fileID: 7150267262384080733}
   ElementNameText: {fileID: 5693523784224329242}
   ElementToggle: {fileID: 6363628182054740200}
   XPosInput: {fileID: 1651071714595890500}
@@ -12496,8 +12663,8 @@ MonoBehaviour:
   m_FillRect: {fileID: 2598324992479817966}
   m_HandleRect: {fileID: 2731359021802261551}
   m_Direction: 0
-  m_MinValue: -1
-  m_MaxValue: 1
+  m_MinValue: -1.5
+  m_MaxValue: 1.5
   m_WholeNumbers: 0
   m_Value: 0
   m_OnValueChanged:
@@ -13570,6 +13737,97 @@ MonoBehaviour:
   m_hasFontAssetChanged: 1
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &9000938316990935969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9161835482758760361}
+  - component: {fileID: 3616771453448931557}
+  - component: {fileID: 2373156634136147033}
+  - component: {fileID: 4860187610849468619}
+  m_Layer: 5
+  m_Name: Letterbox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9161835482758760361
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000938316990935969}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8823099424137248163}
+  m_Father: {fileID: 3848485333487225133}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -24}
+  m_SizeDelta: {x: 0, y: -48}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3616771453448931557
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000938316990935969}
+  m_CullTransparentMesh: 1
+--- !u!114 &2373156634136147033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000938316990935969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 501845c08f33b374490e069f771bba33, type: 3}
+  m_Type: 2
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 1
+  m_PixelsPerUnitMultiplier: 64
+--- !u!114 &4860187610849468619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000938316990935969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
 --- !u!1 &9029733021468065989
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/GameTex.renderTexture
+++ b/Assets/Resources/Prefabs/GameTex.renderTexture
@@ -18,7 +18,7 @@ RenderTexture:
   m_Height: 1259
   m_AntiAliasing: 1
   m_MipCount: -1
-  m_DepthFormat: 2
+  m_DepthFormat: 0
   m_ColorFormat: 8
   m_MipMap: 0
   m_GenerateMips: 1
@@ -28,7 +28,7 @@ RenderTexture:
   m_EnableCompatibleFormat: 1
   m_TextureSettings:
     serializedVersion: 2
-    m_FilterMode: 0
+    m_FilterMode: 1
     m_Aniso: 0
     m_MipBias: 0
     m_WrapU: 0

--- a/Assets/Resources/Prefabs/GameTexMaterial.mat
+++ b/Assets/Resources/Prefabs/GameTexMaterial.mat
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GameTexMaterial
+  m_Shader: {fileID: 4800000, guid: 0596a6838d78f624397b642817cf20bc, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _InvFade: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UVSec: 0
+    - _UseUIAlphaClip: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/Prefabs/GameTexMaterial.mat.meta
+++ b/Assets/Resources/Prefabs/GameTexMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7c8faa192101444499e552f68b68e8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/OverlayTex.renderTexture
+++ b/Assets/Resources/Prefabs/OverlayTex.renderTexture
@@ -14,8 +14,8 @@ RenderTexture:
   m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
   serializedVersion: 3
-  m_Width: 2238
-  m_Height: 1259
+  m_Width: 3357
+  m_Height: 1888
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthFormat: 2
@@ -28,7 +28,7 @@ RenderTexture:
   m_EnableCompatibleFormat: 1
   m_TextureSettings:
     serializedVersion: 2
-    m_FilterMode: 0
+    m_FilterMode: 1
     m_Aniso: 0
     m_MipBias: 0
     m_WrapU: 0

--- a/Assets/Resources/Prefabs/OverlayTexMaterial.mat
+++ b/Assets/Resources/Prefabs/OverlayTexMaterial.mat
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OverlayTexMaterial
+  m_Shader: {fileID: 4800000, guid: 0596a6838d78f624397b642817cf20bc, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _InvFade: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UVSec: 0
+    - _UseUIAlphaClip: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/Prefabs/OverlayTexMaterial.mat.meta
+++ b/Assets/Resources/Prefabs/OverlayTexMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5b6c66ebe6a79448978a7cb25df9202
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GlobalGameManager.cs
+++ b/Assets/Scripts/GlobalGameManager.cs
@@ -208,8 +208,8 @@ namespace HeavenStudio
             GameRenderTexture.width = width;
             GameRenderTexture.height = height;
 
-            OverlayRenderTexture.width = width;
-            OverlayRenderTexture.height = height;
+            OverlayRenderTexture.width = (int)(width * 1.5f);
+            OverlayRenderTexture.height = (int)(height * 1.5f);
         }
 
         public static void ChangeMasterVolume(float value)

--- a/Assets/Scripts/LevelEditor/SettingsDialog/Tabs/GameSettings.cs
+++ b/Assets/Scripts/LevelEditor/SettingsDialog/Tabs/GameSettings.cs
@@ -14,12 +14,19 @@ namespace HeavenStudio.Editor
     public class GameSettings : TabsContent
     {
         public static bool InPreview;
+        static Color ambiColour;
+        static bool needUpdateAmbi;
         [SerializeField] Toggle editorOverlaysToggle;
         [SerializeField] Toggle perfectChallengeToggle;
         [SerializeField] Toggle sectionMedalsToggle;
         [SerializeField] Toggle timingDispMinModeToggle;
         [SerializeField] Toggle letterboxBgEnable;
         [SerializeField] Toggle letterboxFxEnable;
+
+        [SerializeField] Image LytEditBg;
+        [SerializeField] Image LytEditBgAmbi;
+        [SerializeField] GameObject LytEditBgAmbiGO;
+
 
         [Header("Layout Settings - Header")]
         [SerializeField] TMP_Text ElementNameText;
@@ -47,6 +54,14 @@ namespace HeavenStudio.Editor
 
         const string fFormat = "0.000";
 
+        bool initLyt = false;
+
+        public static void UpdatePreviewAmbient(Color col)
+        {
+            ambiColour = col;
+            needUpdateAmbi = true;
+        }
+
         // Start is called before the first frame update
         void Start()
         {
@@ -56,7 +71,11 @@ namespace HeavenStudio.Editor
         // Update is called once per frame
         void Update()
         {
-
+            if (InPreview && needUpdateAmbi)
+            {
+                LytEditBgAmbi.color = ambiColour;
+                needUpdateAmbi = false;
+            }
         }
 
         void CreateDefaultLayout()
@@ -99,12 +118,14 @@ namespace HeavenStudio.Editor
         {
             PersistentDataManager.gameSettings.letterboxBgEnable = letterboxBgEnable.isOn;
             StaticCamera.instance.ToggleLetterboxBg(PersistentDataManager.gameSettings.letterboxBgEnable);
+            LytEditBg.color = PersistentDataManager.gameSettings.letterboxBgEnable ? Color.white : Color.black;
         }
 
         public void OnLetterboxFxToggleChanged()
         {
             PersistentDataManager.gameSettings.letterboxFxEnable = letterboxFxEnable.isOn;
             StaticCamera.instance.ToggleLetterboxGlow(PersistentDataManager.gameSettings.letterboxFxEnable);
+            LytEditBgAmbiGO.SetActive(PersistentDataManager.gameSettings.letterboxFxEnable);
         }
 
         public override void OnOpenTab()
@@ -133,6 +154,7 @@ namespace HeavenStudio.Editor
 
             UpdateLayoutSettings();
             InPreview = true;
+            initLyt = true;
         }
 
         public override void OnCloseTab()
@@ -143,6 +165,7 @@ namespace HeavenStudio.Editor
             }
             lytElements.Clear();
             InPreview = false;
+            initLyt = false;
         }
 
         void UpdateLayoutSettings()
@@ -194,6 +217,7 @@ namespace HeavenStudio.Editor
 
         public void OnElementToggled()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             element.enable = ElementToggle.isOn;
             element.PositionElement();
@@ -201,6 +225,7 @@ namespace HeavenStudio.Editor
 
         public void OnXPosInputChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             XPosSlider.value = float.Parse(XPosInput.text);
             element.position.x = XPosSlider.value;
@@ -209,6 +234,7 @@ namespace HeavenStudio.Editor
 
         public void OnXPosSliderChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             XPosInput.text = XPosSlider.value.ToString(fFormat);
             element.position.x = XPosSlider.value;
@@ -217,6 +243,7 @@ namespace HeavenStudio.Editor
 
         public void OnYPosInputChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             YPosSlider.value = float.Parse(YPosInput.text);
             element.position.y = YPosSlider.value;
@@ -225,6 +252,7 @@ namespace HeavenStudio.Editor
 
         public void OnYPosSliderChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             YPosInput.text = YPosSlider.value.ToString(fFormat);
             element.position.y = YPosSlider.value;
@@ -233,6 +261,7 @@ namespace HeavenStudio.Editor
 
         public void OnRotationInputChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             RotationSlider.value = float.Parse(RotationInput.text);
             element.rotation = RotationSlider.value;
@@ -241,6 +270,7 @@ namespace HeavenStudio.Editor
 
         public void OnRotationSliderChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             RotationInput.text = RotationSlider.value.ToString(fFormat);
             element.rotation = RotationSlider.value;
@@ -249,6 +279,7 @@ namespace HeavenStudio.Editor
 
         public void OnScaleInputChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             ScaleSlider.value = float.Parse(ScaleInput.text);
             element.scale = ScaleSlider.value;
@@ -257,6 +288,7 @@ namespace HeavenStudio.Editor
 
         public void OnScaleSliderChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx];
             ScaleInput.text = ScaleSlider.value.ToString(fFormat);
             element.scale = ScaleSlider.value;
@@ -265,6 +297,7 @@ namespace HeavenStudio.Editor
 
         public void OnTimingDispTypeDropdownChanged()
         {
+            if (!initLyt) return;
             var element = lytElements[currentElementIdx] as OverlaysManager.TimingDisplayComponent;
             if (element == null) return;
             element.tdType = (OverlaysManager.TimingDisplayComponent.TimingDisplayType)TimingDispTypeDropdown.value;

--- a/Assets/Scripts/StaticCamera.cs
+++ b/Assets/Scripts/StaticCamera.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 
 using HeavenStudio.Util;
 using HeavenStudio.Common;
+using HeavenStudio.Editor;
 
 namespace HeavenStudio
 {
@@ -210,6 +211,7 @@ namespace HeavenStudio
         public void SetAmbientGlowColour(Color colour)
         {
             ambientBg.color = colour;
+            GameSettings.UpdatePreviewAmbient(colour);
         }
 
         public void ToggleLetterboxBg(bool toggle)


### PR DESCRIPTION
## Overlays
- Game overlays can now be positioned off-screen (in the letterbox area) ![image](https://user-images.githubusercontent.com/43734252/224577014-c9aae012-bc2b-40c6-8470-7fba7ee7d27a.png)
- Letterbox and Ambient Glow settings are now shown in the UI Editor preview 
![image](https://user-images.githubusercontent.com/43734252/224577045-6107db3e-501b-45b0-afe7-7886661ff6de.png)


## Playback
- Resolved issues with transparent objects in the game scene overriding game RenderTexture alpha