### PR TITLE
Ctrl-A in textboxes bug

### DIFF
--- a/Assets/Scripts/LevelEditor/EventSelector/PropertyPrefabs/StringPropertyPrefab.cs
+++ b/Assets/Scripts/LevelEditor/EventSelector/PropertyPrefabs/StringPropertyPrefab.cs
@@ -32,6 +32,11 @@ namespace HeavenStudio.Editor
                 _ =>
                 {;
                     parameterManager.entity[propertyName] = inputFieldString.text;
+                }
+            );
+            inputFieldString.onEndEdit.AddListener(
+                _ =>
+                {;
                     Editor.instance.editingInputField = false;
                 }
             );

--- a/Assets/Scripts/LevelEditor/Selections.cs
+++ b/Assets/Scripts/LevelEditor/Selections.cs
@@ -24,11 +24,14 @@ namespace HeavenStudio.Editor
             if (buggedSelections.Count > 0)
             {
                 for (int i = 0; i < buggedSelections.Count; i++)
-                Deselect(buggedSelections[i]);
+                    Deselect(buggedSelections[i]);
             }
-            if (Input.GetKey(KeyCode.LeftControl))
-                if (Input.GetKeyDown(KeyCode.A))
-                    SelectAll();
+            if (Editor.instance.isShortcutsEnabled)
+            {
+                if (Input.GetKey(KeyCode.LeftControl))
+                    if (Input.GetKeyDown(KeyCode.A))
+                        SelectAll();
+            }
         }
 
         public void ClickSelect(TimelineEventObj eventToAdd)


### PR DESCRIPTION
Ctrl-A is correctly blocked from triggering the timeline select all shortcut if a text box is being edited.