### PR TITLE
Fix Cheer Readers camera

### DIFF
--- a/Assets/Scripts/Games/CheerReaders/CheerReaders.cs
+++ b/Assets/Scripts/Games/CheerReaders/CheerReaders.cs
@@ -201,7 +201,6 @@ namespace HeavenStudio.Games
             allGirls.AddRange(secondRow);
             allGirls.AddRange(thirdRow);
             var camEvents = EventCaller.GetAllInGameManagerList("cheerReaders", new string[] { "okItsOn" });
-            camEvents.AddRange(EventCaller.GetAllInGameManagerList("cheerReaders", new string[] { "okItsOnStretch" }));
             List<DynamicBeatmap.DynamicEntity> tempEvents = new List<DynamicBeatmap.DynamicEntity>();
             for (int i = 0; i < camEvents.Count; i++)
             {


### PR DESCRIPTION
`EventCaller.GetAllInGameManagerList` returns any events that contain the include string regardless of if they are an exact match or not, so Cheer Readers was adding all the events twice (the first query returns both kinds of "Ok It's On!"), and then scheduling zooms in the wrong places.

Since I'm new and dumb I'm not really comfortable making the call for how that function _should_ work, for now this makes the Cheer Readers zoom ins behave as expected.