### PR TITLE
Sound Scheduling Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/*/*
 /[Aa]ssets/[Ss]treamingAssets/*.manifest
 /[Aa]ssets/[Ss]treamingAssets/*.meta
+/[Aa]ssets/[Ss]treamingAssets/[Ss]treamingAssets
+Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset

--- a/Assets/Scripts/LevelEditor/Editor.cs
+++ b/Assets/Scripts/LevelEditor/Editor.cs
@@ -250,7 +250,7 @@ namespace HeavenStudio.Editor
         {
             var extensions = new[]
             {
-                new ExtensionFilter("Music Files", "mp3", "ogg", "wav")
+                new ExtensionFilter("Music Files", "mp3", "ogg", "wav", "aiff", "aif", "aifc")
             };
 
             #if UNITY_STANDALONE_WINDOWS

--- a/Assets/Scripts/Util/SoundByte.cs
+++ b/Assets/Scripts/Util/SoundByte.cs
@@ -235,7 +235,6 @@ namespace HeavenStudio.Util
             
             snd.scheduled = true;
             snd.scheduledTime = targetTime;
-            audioSource.PlayScheduled(targetTime);
             
             GameManager.instance.SoundObjects.Add(oneShot);
 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,7 +8,7 @@
         "com.unity.nuget.newtonsoft-json": "3.2.1",
         "jillejr.newtonsoft.json-for-unity.converters": "1.5.1"
       },
-      "hash": "2fb235a6da261fb1ae60112f9e9ba0d924e96bb8"
+      "hash": "ac56f4d95417af5dbedf20f3b8d79b9f67c72659"
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These builds include experimental new features that will not be included in Rele
 
 
 #### Important Notes:
+- Certain types of mp3 audio may [desync when seeking in the editor](https://github.com/RHeavenStudio/HeavenStudio/issues/490). Either use mp3s with constant bitrate encoding or use one of our other supported formats (ogg, wav...)
 - On MacOS and Linux builds you may [experience bugs with audio-related tasks](https://github.com/RHeavenStudio/HeavenStudio/issues/72), but in most cases Heaven Studio works perfectly.
 - On MacOS you'll need to have Discord open in the background for now, there's a bug that causes the DiscordSDK library to crash when the rich presence is updated while Discord is not open in the background.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ These builds include experimental new features that will not be included in Rele
 
 
 #### Important Notes:
-- Certain types of mp3 audio may [desync when seeking in the editor](https://github.com/RHeavenStudio/HeavenStudio/issues/490). Either use mp3s with constant bitrate encoding or use one of our other supported formats (ogg, wav...)
+- MP3 audio with variable bitrate encoding may [desync when seeking in the editor](https://github.com/RHeavenStudio/HeavenStudio/issues/490). Either use MP3s with constant bitrate encoding or use one of our other supported formats (OGG Vorbis, WAV...)
 - On MacOS and Linux builds you may [experience bugs with audio-related tasks](https://github.com/RHeavenStudio/HeavenStudio/issues/72), but in most cases Heaven Studio works perfectly.
 - On MacOS you'll need to have Discord open in the background for now, there's a bug that causes the DiscordSDK library to crash when the rich presence is updated while Discord is not open in the background.
 


### PR DESCRIPTION
- SoundByte scheduled sounds won't schedule playback until their time to play is close enough (currently 0.5 seconds before)
- Made conductor `SetBeat()` share same audio seek logic as `Play()`
- Audio offset is applied before playback to the absolute time instead of being "invisibly" applied during calculation of beat position
- Allow AIFF audio files to be imported in editor (let us know if this breaks)
- Added note to readme warning about desync issues with VBR-encoded MP3s (#490)