### PR TITLE
Game Switch Black Flash is now beat-based.

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -840,20 +840,20 @@ namespace HeavenStudio
             if (GetGameInfo(currentGame) != null)
             {
                 CircleCursor.InnerCircle.GetComponent<SpriteRenderer>().color = Colors.Hex2RGB(GetGameInfo(currentGame).color);
-                if (useMinigameColor) HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color));
-                else HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Color.black);
+                if (useMinigameColor) HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color), true);
+                else HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(HeavenStudio.GameCamera.currentColor, false);
             }
             else
             {
                 CircleCursor.InnerCircle.GetComponent<SpriteRenderer>().color = Color.white;
-                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Color.black);
+                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(HeavenStudio.GameCamera.currentColor, false);
             }
         }
 
         private void SetAmbientGlowToCurrentMinigameColor()
         {
             if (GetGameInfo(currentGame) != null) 
-                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color));
+                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color), true);
         }
 
         private bool SongPosLessThanClipLength(float t)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -761,7 +761,7 @@ namespace HeavenStudio
 
         IEnumerator SwitchGameIE(string game, double beat, bool flash)
         {
-            if(flash == true)
+            if(flash)
             {
                 HeavenStudio.StaticCamera.instance.ToggleCanvasVisibility(false);
             }
@@ -772,8 +772,8 @@ namespace HeavenStudio
             if (miniGame != null)
                 miniGame.OnGameSwitch(beat);
 
-            //TODO: wait time in beats instead of seconds
-            yield return new WaitForSeconds(0.1f);
+            //before beat-based: yield return new WaitForSeconds(0.1f);
+            yield return new WaitForSeconds(Conductor.instance.pitchedSecPerBeat / 4);
 
             HeavenStudio.StaticCamera.instance.ToggleCanvasVisibility(true);
         }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -841,12 +841,14 @@ namespace HeavenStudio
             {
                 CircleCursor.InnerCircle.GetComponent<SpriteRenderer>().color = Colors.Hex2RGB(GetGameInfo(currentGame).color);
                 if (useMinigameColor) HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color), true);
-                else HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(HeavenStudio.GameCamera.currentColor, false);
+                //else HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(HeavenStudio.GameCamera.currentColor, false);
+                else HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Color.black, false);
             }
             else
             {
                 CircleCursor.InnerCircle.GetComponent<SpriteRenderer>().color = Color.white;
-                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(HeavenStudio.GameCamera.currentColor, false);
+                //HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(HeavenStudio.GameCamera.currentColor, false);
+                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Color.black, false);
             }
         }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -766,7 +766,7 @@ namespace HeavenStudio
                 HeavenStudio.StaticCamera.instance.ToggleCanvasVisibility(false);
             }
 
-            SetGame(game);
+            SetGame(game, false);
 
             Minigame miniGame = currentGameO.GetComponent<Minigame>();
             if (miniGame != null)
@@ -776,9 +776,10 @@ namespace HeavenStudio
             yield return new WaitForSeconds(Conductor.instance.pitchedSecPerBeat / 4);
 
             HeavenStudio.StaticCamera.instance.ToggleCanvasVisibility(true);
+            SetAmbientGlowToCurrentMinigameColor();
         }
 
-        private void SetGame(string game)
+        private void SetGame(string game, bool useMinigameColor = true)
         {
             Destroy(currentGameO);
 
@@ -786,7 +787,7 @@ namespace HeavenStudio
             currentGameO.transform.parent = eventCaller.GamesHolder.transform;
             currentGameO.name = game;
 
-            SetCurrentGame(game);
+            SetCurrentGame(game, useMinigameColor);
 
             ResetCamera();
         }
@@ -833,19 +834,26 @@ namespace HeavenStudio
             return EventCaller.instance.minigames.Find(c => c.name == name);
         }
 
-        public void SetCurrentGame(string game)
+        public void SetCurrentGame(string game, bool useMinigameColor = true)
         {
             currentGame = game;
             if (GetGameInfo(currentGame) != null)
             {
                 CircleCursor.InnerCircle.GetComponent<SpriteRenderer>().color = Colors.Hex2RGB(GetGameInfo(currentGame).color);
-                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color));
+                if (useMinigameColor) HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color));
+                else HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Color.black);
             }
             else
             {
                 CircleCursor.InnerCircle.GetComponent<SpriteRenderer>().color = Color.white;
                 HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Color.black);
             }
+        }
+
+        private void SetAmbientGlowToCurrentMinigameColor()
+        {
+            if (GetGameInfo(currentGame) != null) 
+                HeavenStudio.StaticCamera.instance.SetAmbientGlowColour(Colors.Hex2RGB(GetGameInfo(currentGame).color));
         }
 
         private bool SongPosLessThanClipLength(float t)

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -677,6 +677,13 @@ namespace HeavenStudio
                             new Param("axis", GameCamera.CameraAxis.All, "Axis", "The axis to move the camera on" )
                         } 
                     ),
+                    new GameAction("camera background color", "Camera Background Color", 1, true, new List<Param>()
+                        {
+                            new Param("color", Color.black, "Start Color"),
+                            new Param("color2", Color.black, "End Color"),
+                            new Param("ease", Util.EasingFunction.Ease.Linear, "Ease Type")
+                        }
+                    ),
                     new GameAction("pan view", "Pan Viewport", 1f, true, new List<Param>() 
                         {
                             new Param("valA", new EntityTypes.Float(-50, 50, 0), "Right / Left", "Next position on the X axis"),

--- a/Assets/Scripts/StaticCamera.cs
+++ b/Assets/Scripts/StaticCamera.cs
@@ -8,6 +8,7 @@ using HeavenStudio.Common;
 using HeavenStudio.Editor;
 using Jukebox;
 using Jukebox.Legacy;
+using System;
 
 namespace HeavenStudio
 {
@@ -210,8 +211,11 @@ namespace HeavenStudio
             overlayView.SetActive(toggle);
         }
 
-        public void SetAmbientGlowColour(Color colour)
+        [NonSerialized] public bool usingMinigameAmbientColor;
+
+        public void SetAmbientGlowColour(Color colour, bool minigameColor, bool overrideMinigameColor = true)
         {
+            if (overrideMinigameColor) usingMinigameAmbientColor = minigameColor;
             ambientBg.color = colour;
             GameSettings.UpdatePreviewAmbient(colour);
         }


### PR DESCRIPTION
The black flash when a game switches is now 0.25 beats long.

VFX:
Added camera background color event. It allows you to change the color of the black void behind a minigame scene. Be aware it doesn't change the color of the black flash.

Letterbox:
Color goes black while the black game switch flash is active.