### PR TITLE
Misc. Tweaks the tweakquel

### DIFF
--- a/Assets/Scripts/Games/AirRally/AirRally.cs
+++ b/Assets/Scripts/Games/AirRally/AirRally.cs
@@ -188,7 +188,10 @@ namespace HeavenStudio.Games.Loaders
                     resizable = true,
                     parameters = new List<Param>()
                     {
-                        new Param("enable", true, "Enable"),
+                        new Param("enable", true, "Enable", "", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "main", "side", "speed", "endSpeed", "ease" })
+                        }),
                         new Param("main", new EntityTypes.Integer(0, 300, 50), "Main Trees", "How many trees per second?"),
                         new Param("side", new EntityTypes.Integer(0, 100, 30), "Side Trees", "How many trees per second?"),
                         new Param("speed", new EntityTypes.Float(-10, 10, 1), "Speed Multiplier"),

--- a/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
+++ b/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
@@ -22,7 +22,10 @@ namespace HeavenStudio.Games.Loaders
                     resizable = true,
                     parameters = new List<Param>()
                     {
-                        new Param("silent", false, "Mute Audio", "Whether the piano notes should be muted or not."),
+                        new Param("silent", false, "Mute Audio", "Whether the piano notes should be muted or not.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => !(bool)x, new string[] { "note1", "note2", "note3", "note4", "note5", "note6"})
+                        }),
                         new Param("note1", new EntityTypes.Integer(-24, 24, 0), "1st note", "The number of semitones up or down this note should be pitched"),
                         new Param("note2", new EntityTypes.Integer(-24, 24, 2), "2nd note", "The number of semitones up or down this note should be pitched"),
                         new Param("note3", new EntityTypes.Integer(-24, 24, 4), "3rd note", "The number of semitones up or down this note should be pitched"),

--- a/Assets/Scripts/Games/CatchyTune/CatchyTune.cs
+++ b/Assets/Scripts/Games/CatchyTune/CatchyTune.cs
@@ -20,7 +20,10 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>()
                     {
                         new Param("side", CatchyTune.Side.Left, "Side", "The side the orange falls down"),
-                        new Param("smile", false, "Smile", "If the characters smile with the heart message after catching"),
+                        new Param("smile", false, "Smile", "If the characters smile with the heart message after catching", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "endSmile" })
+                        }),
                         new Param("endSmile", new EntityTypes.Float(2, 100), "End Smile Beat", "How many beats after the catch should the smile end?")
                     },
                     preFunction = delegate {var e = eventCaller.currentEntity; CatchyTune.PreDropFruit(e.beat, e["side"], e["smile"], false, e["endSmile"]); },
@@ -32,7 +35,10 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>()
                     {
                         new Param("side", CatchyTune.Side.Left, "Side", "The side the pineapple falls down"),
-                        new Param("smile", false, "Smile", "If the characters smile with the heart message after catching"),
+                        new Param("smile", false, "Smile", "If the characters smile with the heart message after catching", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "endSmile" })
+                        }),
                         new Param("endSmile", new EntityTypes.Float(2, 100), "End Smile Beat", "How many beats after the catch should the smile end?")
                     },
                     preFunction = delegate {var e = eventCaller.currentEntity; CatchyTune.PreDropFruit(e.beat, e["side"], e["smile"], true, e["endSmile"]); },

--- a/Assets/Scripts/Games/CropStomp/CropStomp.cs
+++ b/Assets/Scripts/Games/CropStomp/CropStomp.cs
@@ -55,7 +55,10 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("threshold", new EntityTypes.Integer(1, 80, 8), "Threshold", "For each time the threshold is met a new plant will appear in the veggie bag."),
                         new Param("limit", new EntityTypes.Integer(1, 1000, 80), "Limit", "What is the limit for plants collected?"),
-                        new Param("force", false, "Force Amount of Collected Plants"),
+                        new Param("force", false, "Force Amount of Collected Plants", "", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "forceAmount" })
+                        }),
                         new Param("forceAmount", new EntityTypes.Integer(0, 1000, 0), "Force Amount")
                     }
                 }

--- a/Assets/Scripts/Games/DrummingPractice/DrummingPractice.cs
+++ b/Assets/Scripts/Games/DrummingPractice/DrummingPractice.cs
@@ -39,10 +39,13 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 0.5f, 
                     parameters = new List<Param>()
                     {
+                        new Param("toggle", false, "Set All to Player", "Sets all Miis to the Player's Mii", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => !(bool)x, new string[] { "type", "type2", "type3" })
+                        }),
                         new Param("type", DrummingPractice.MiiType.Random, "Player Mii", "The Mii that the player will control"),
                         new Param("type2", DrummingPractice.MiiType.Random, "Left Mii", "The Mii on the left"),
                         new Param("type3", DrummingPractice.MiiType.Random, "Right Mii", "The Mii on the right"),
-                        new Param("toggle", false, "Set All to Player", "Sets all Miis to the Player's Mii")
                     }
                 },
                 new GameAction("move npc drummers", "NPC Drummers Enter or Exit")

--- a/Assets/Scripts/Games/FirstContact/FirstContact.cs
+++ b/Assets/Scripts/Games/FirstContact/FirstContact.cs
@@ -25,7 +25,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("dialogue", "REPLACE THIS", "Mistranslation Dialogue", "The line to use when messing up the translation"),
                         new Param("auto", true, "Auto Pass Turn")
                     },
-                    defaultLength = 4f,
+                    defaultLength = 3f,
                     resizable = true,
                     priority = 2,
                 },
@@ -43,6 +43,7 @@ namespace HeavenStudio.Games.Loaders
                 new GameAction("alien turnover", "Pass Turn")
                 {
                     function = delegate { FirstContact.instance.PassTurnStandalone(eventCaller.currentEntity.beat);  },
+                    resizable = true,
                 },
                 new GameAction("alien success", "Success")
                 {
@@ -250,7 +251,7 @@ namespace HeavenStudio.Games
                     translateFailTextbox.SetActive(false);
                     if (autoPassTurn)
                     {
-                        AlienTurnOver(beat + interval, beat, beat + interval);
+                        AlienTurnOver(beat + interval, beat, beat + interval, 1);
                     }
                 })
             };
@@ -387,11 +388,12 @@ namespace HeavenStudio.Games
         public void PassTurnStandalone(double beat)
         {
             RiqEntity lastInterval = GetLastIntervalBeforeBeat(beat);
+            float length = EventCaller.GetAllInGameManagerList("firstContact", new string[] { "alien turnover" }).Find(x => x.beat == beat).length;
             if (lastInterval == null) return;
-            AlienTurnOver(beat, lastInterval.beat, lastInterval.beat + lastInterval.length);
+            AlienTurnOver(beat, lastInterval.beat, lastInterval.beat + lastInterval.length, length);
         }
 
-        private void AlienTurnOver(double beat, double intervalBeat, double endBeat)
+        private void AlienTurnOver(double beat, double intervalBeat, double endBeat, float length)
         {
             var inputs = GetAllSpeaksInBetweenBeat(intervalBeat, endBeat);
             inputs.Sort((x, y) => x.beat.CompareTo(y.beat));
@@ -399,7 +401,7 @@ namespace HeavenStudio.Games
             {
                 var input = inputs[i];
                 double relativeBeat = input.beat - intervalBeat;
-                ScheduleInput(beat, 1 + relativeBeat, InputType.STANDARD_DOWN | InputType.DIRECTION_DOWN, AlienTapping, AlienOnMiss, AlienEmpty);
+                ScheduleInput(beat, length + relativeBeat, InputType.STANDARD_DOWN | InputType.DIRECTION_DOWN, AlienTapping, AlienOnMiss, AlienEmpty);
                 callDiagList.Add(input["dialogue"]);
             }
             BeatAction.New(gameObject, new List<BeatAction.Action>()
@@ -411,7 +413,7 @@ namespace HeavenStudio.Games
                     alienTextbox.SetActive(false);
                     alien.Play("alien_point", 0, 0);
                 }),
-                new BeatAction.Action(beat + 0.5f, delegate 
+                new BeatAction.Action(beat + (length / 2), delegate 
                 { 
                     alien.Play("alien_idle", 0, 0); 
                 })

--- a/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
+++ b/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
@@ -57,9 +57,15 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>()
                     {
                         new Param("uh", new EntityTypes.Integer(0, 3, 0), "Uh Count", "How many Uhs should Captain Tuck say after the flippers roll?"),
-                        new Param("thatsIt", false, "That's it!", "Whether or not Captain Tuck should say -That's it!- on the final flipper roll."),
-                        new Param("appreciation", FlipperFlop.AppreciationType.None, "Appreciation", "Which appreciation line should Captain Tuck say?"),
+                        new Param("appreciation", FlipperFlop.AppreciationType.None, "Appreciation", "Which appreciation line should Captain Tuck say?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (int)x != (int)FlipperFlop.AppreciationType.None, new string[] { "heart" })
+                        }),
                         new Param("heart", false, "Hearts", "Should Captain Tuck blush and make hearts appear when he expresses his appreciation?"),
+                        new Param("thatsIt", false, "That's it!", "Whether or not Captain Tuck should say -That's it!- on the final flipper roll.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "barber" })
+                        }),
                         new Param("barber", false, "Barbershop that's it variant", "Should captain tuck use the Barbershop remix variant of that's it?")
                     },
                     defaultLength = 4f,

--- a/Assets/Scripts/Games/GleeClub/GleeClub.cs
+++ b/Assets/Scripts/Games/GleeClub/GleeClub.cs
@@ -29,7 +29,10 @@ namespace HeavenStudio.Games.Loaders
                         new Param("semiTones1", new EntityTypes.Integer(-24, 24, -1), "Semitones (Next)", "The number of semitones up or down this note should be pitched"),
                         new Param("semiTonesPlayer", new EntityTypes.Integer(-24, 24, 2), "Semitones (Player)", "The number of semitones up or down this note should be pitched"),
                         new Param("close", GleeClub.MouthOpenClose.Both, "Close/Open Mouth", "Should the chorus kids close/open their mouth?"),
-                        new Param("repeat", false, "Repeating", "Should the left and middle chorus kid repeat this singing cue?"),
+                        new Param("repeat", false, "Repeating", "Should the left and middle chorus kid repeat this singing cue?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "semiTonesLeft2", "semiTonesLeft3", "semiTonesMiddle2" })
+                        }),
                         new Param("semiTonesLeft2", new EntityTypes.Integer(-24, 24, 0), "Semitones (Repeat Left First)", "The number of semitones up or down this note should be pitched"),
                         new Param("semiTonesLeft3", new EntityTypes.Integer(-24, 24, 0), "Semitones (Repeat Left Last)", "The number of semitones up or down this note should be pitched"),
                         new Param("semiTonesMiddle2", new EntityTypes.Integer(-24, 24, 0), "Semitones (Repeat Middle)", "The number of semitones up or down this note should be pitched"),

--- a/Assets/Scripts/Games/LaunchParty/LaunchParty.cs
+++ b/Assets/Scripts/Games/LaunchParty/LaunchParty.cs
@@ -121,7 +121,10 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 0.5f,
                     parameters = new List<Param>()
                     {
-                        new Param("toggle", true, "Stars Enabled", "Starfall Or No?"),
+                        new Param("toggle", true, "Stars Enabled", "Starfall Or No?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "valA", "valB", "valC"})
+                        }),
                         new Param("valA", new EntityTypes.Float(0.1f, 10f, 1f), "Star Density", "How many stars are on the screen"),
                         new Param("valB", new EntityTypes.Float(0.01f, 5f, 0.1f), "Front Star Fall Speed", "How fast the front stars fall to the edge of the screen"),
                         new Param("valC", new EntityTypes.Float(0.01f, 5f, 0.1f), "Back Star Fall Speed", "How fast the stars fall to the edge of the screen")

--- a/Assets/Scripts/Games/Lockstep/Lockstep.cs
+++ b/Assets/Scripts/Games/Lockstep/Lockstep.cs
@@ -104,7 +104,10 @@ namespace HeavenStudio.Games.Loaders
                     preFunction = delegate {var e = eventCaller.currentEntity; Lockstep.Marching(e.beat, e["sound"], e["amount"], e["visual"], true, e.length);},
                     parameters = new List<Param>()
                     {
-                        new Param("sound", false, "Sound", "Hai if onbeat, ho if offbeat."),
+                        new Param("sound", false, "Sound", "Hai if onbeat, ho if offbeat.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "amount" })
+                        }),
                         new Param("amount", new EntityTypes.Integer(1, 50, 1), "Sound Amount", "How many sounds will play consecutively?"),
                         new Param("visual", true, "Background Visual")
                     },

--- a/Assets/Scripts/Games/Lockstep/Lockstep.cs
+++ b/Assets/Scripts/Games/Lockstep/Lockstep.cs
@@ -34,7 +34,10 @@ namespace HeavenStudio.Games.Loaders
                     preFunction = delegate {var e = eventCaller.currentEntity; Lockstep.Marching(e.beat, e["sound"], e["amount"], e["visual"]);},
                     parameters = new List<Param>()
                     {
-                        new Param("sound", false, "Sound", "Hai if onbeat, ho if offbeat."),
+                        new Param("sound", false, "Sound", "Hai if onbeat, ho if offbeat.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "amount" })
+                        }),
                         new Param("amount", new EntityTypes.Integer(1, 50, 1), "Sound Amount", "How many sounds will play consecutively?"),
                         new Param("visual", true, "Background Visual")
                     },
@@ -61,6 +64,14 @@ namespace HeavenStudio.Games.Loaders
                         new Param("hai", new EntityTypes.Integer(0, 100, 1), "Hai Amount"),
                         new Param("visual", true, "Background Visual")
                     }
+                },
+                new GameAction("hai", "Hai")
+                {
+                    preFunction = delegate { Lockstep.HaiSound(eventCaller.currentEntity.beat); }
+                },
+                new GameAction("ho", "Ho")
+                {
+                    preFunction = delegate { Lockstep.HoSound(eventCaller.currentEntity.beat); }
                 },
                 new GameAction("set colours", "Set Colours")
                 {
@@ -229,6 +240,11 @@ namespace HeavenStudio.Games
             }
 
             bachEvents = EventCaller.GetAllInGameManagerList("lockstep", new string[] { "bach" });
+        }
+
+        private static bool ForceStepOnBeat(double beat)
+        {
+            return EventCaller.GetAllInGameManagerList("lockstep", new string[] { "marching" }).Find(x => beat >= x.beat && beat < x.beat + x.length) != null;
         }
 
         private void PersistColors(double beat)
@@ -402,6 +418,16 @@ namespace HeavenStudio.Games
             }
         }
 
+        public static void HaiSound(double beat)
+        {
+            SoundByte.PlayOneShot("games/lockstep/hai", beat, 1, 1, false, null, 0.02314814814f);
+        }
+        
+        public static void HoSound(double beat)
+        {
+            SoundByte.PlayOneShot("games/lockstep/ho", beat, 1, 1, false, null, 0.03086419753);
+        }
+
         public static void OnbeatSwitchSound(double beat, int hais, bool sound)
         {
             if (sound)
@@ -456,7 +482,7 @@ namespace HeavenStudio.Games
                 {
                     if (visual) ChangeBeatBackGroundColour(true);
                 }),
-                new BeatAction.Action(beat + 1.75f, delegate { if (!marchRecursing) MarchRecursive(beat + 2f); }),
+                new BeatAction.Action(beat + 1.75f, delegate { if (!marchRecursing && !ForceStepOnBeat(beat + 2f)) MarchRecursive(beat + 2f); }),
                 new BeatAction.Action(beat + 2f, delegate { if (visual) ChangeBeatBackGroundColour(false); }),
             };
             List<BeatAction.Action> actions = new();
@@ -519,7 +545,7 @@ namespace HeavenStudio.Games
                 {
                     if (visual) ChangeBeatBackGroundColour(false);
                 }),
-                new BeatAction.Action(beat + 3.25f, delegate { if (!marchRecursing) MarchRecursive(beat + 3.5f); }),
+                new BeatAction.Action(beat + 3.25f, delegate { if (!marchRecursing && !ForceStepOnBeat(beat + 3.5)) MarchRecursive(beat + 3.5f); }),
                 new BeatAction.Action(beat + 3.5f, delegate { if (visual) ChangeBeatBackGroundColour(true); }),
             };
             List<BeatAction.Action> actions = new();

--- a/Assets/Scripts/Games/OctopusMachine/OctopusMachine.cs
+++ b/Assets/Scripts/Games/OctopusMachine/OctopusMachine.cs
@@ -42,7 +42,10 @@ namespace HeavenStudio.Games.Loaders
                     },
                     resizable = true,
                     parameters = new List<Param>() {
-                        new Param("shouldPrep", true, "Prepare?", "Plays a prepare animation before the cue."),
+                        new Param("shouldPrep", true, "Prepare?", "Plays a prepare animation before the cue.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "prepBeats" })
+                        }),
                         new Param("prepBeats", new EntityTypes.Float(0, 4, 1), "Prepare Beats", "How many beats before the cue does the octopus prepare?"),
                     },
                     preFunctionLength = 4f,
@@ -79,7 +82,10 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>() {
                         new Param("forceBop", true, "Force Bop", "Forces a bop, even if an animation is playing."),
                         new Param("autoBop", true, "Hit/Miss Bop", "Plays a bop depending on if you hit or missed the cues."),
-                        new Param("autoText", true, "Display Text", "Displays text depending on if you hit or missed the cues."),
+                        new Param("autoText", true, "Display Text", "Displays text depending on if you hit or missed the cues.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "hitText", "missText" })
+                        }),
                         new Param("hitText", "Good!", "Hit Text", "The text to display if you hit the cues."),
                         new Param("missText", "Wrong! Try again!", "Miss Text", "The text to display if you missed the cues."),
                     },
@@ -101,7 +107,10 @@ namespace HeavenStudio.Games.Loaders
                     },
                     parameters = new List<Param>() {
                         new Param("isInstant", true, "Instant", "Will the bubbles disappear appear?"),
-                        new Param("setActive", OctopusMachine.Actives.Activate, "Activate or Deactivate", "Will the bubbles disappear or appear?"),
+                        new Param("setActive", OctopusMachine.Actives.Activate, "Activate or Deactivate", "Will the bubbles disappear or appear?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (int)x == (int)OctopusMachine.Actives.Activate, new string[] { "particleStrength" })
+                        }),
                         new Param("particleStrength", new EntityTypes.Float(0, 25, 3), "Bubble Intensity", "The amount of bubbles"),
                         new Param("particleSpeed", new EntityTypes.Float(0, 25, 5), "Bubble Speed", "The speed of the bubbles"),
                     },
@@ -139,13 +148,22 @@ namespace HeavenStudio.Games.Loaders
                         OctopusMachine.instance.OctopusModifiers(e.beat, e["oct1x"], e["oct2x"], e["oct3x"], e["oct1y"], e["oct2y"], e["oct3y"], e["oct1"], e["oct2"], e["oct3"]);
                     },
                     parameters = new List<Param>() {
-                        new Param("oct1", true, "Show Octopus 1", "Should the first octopus be enabled?"),
+                        new Param("oct1", true, "Show Octopus 1", "Should the first octopus be enabled?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "oct1x", "oct1y" })
+                        }),
                         new Param("oct1x", new EntityTypes.Float(-10, 10, -4.64f), "X Octopus 1", "Change Octopus 1's X"),
                         new Param("oct1y", new EntityTypes.Float(-10, 10, 2.5f), "Y Octopus 1", "Change Octopus 1's Y"),
-                        new Param("oct2", true, "Show Octopus 2", "Should the second octopus be enabled?"),
+                        new Param("oct2", true, "Show Octopus 2", "Should the second octopus be enabled?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "oct2x", "oct2y" })
+                        }),
                         new Param("oct2x", new EntityTypes.Float(-10, 10, -0.637f), "X Octopus 2", "Change Octopus 2's X"),
                         new Param("oct2y", new EntityTypes.Float(-10, 10, 0f), "Y Octopus 2", "Change Octopus 2's Y"),
-                        new Param("oct3", true, "Show Octopus 3", "Should the third octopus be enabled?"),
+                        new Param("oct3", true, "Show Octopus 3", "Should the third octopus be enabled?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "oct3x", "oct3y" })
+                        }),
                         new Param("oct3x", new EntityTypes.Float(-10, 10, 3.363f), "X Octopus 3", "Change Octopus 3's X"),
                         new Param("oct3y", new EntityTypes.Float(-10, 10, -2.5f), "Y Octopus 3", "Change Octopus 3's Y"),
                     },

--- a/Assets/Scripts/Games/QuizShow/QuizShow.cs
+++ b/Assets/Scripts/Games/QuizShow/QuizShow.cs
@@ -521,8 +521,8 @@ namespace HeavenStudio.Games
 
         private void PassTurn(double beat, double intervalBeat, float intervalLength, bool timeUpSound, bool consecutive, bool visualClock, int audioClock, float length)
         {
-            playerStartBeat = beat + length;
-            playerLength = intervalLength;
+            playerStartBeat = beat + length - Conductor.instance.SecsToBeats(ngEarlyTime, Conductor.instance.GetBpmAtBeat(beat + length));
+            playerLength = intervalLength + (float)Conductor.instance.SecsToBeats(ngEarlyTime, Conductor.instance.GetBpmAtBeat(beat + length));
             var relevantInputs = GetInputsBetweenBeat(intervalBeat, intervalBeat + intervalLength);
             relevantInputs.Sort((x, y) => x.beat.CompareTo(y.beat));
 

--- a/Assets/Scripts/Games/QuizShow/QuizShow.cs
+++ b/Assets/Scripts/Games/QuizShow/QuizShow.cs
@@ -17,11 +17,14 @@ namespace HeavenStudio.Games.Loaders
                 {
                     preFunction = delegate { var e = eventCaller.currentEntity; QuizShow.PreInterval(e.beat, e.length, 
                         e["auto"], e["sound"], e["con"], e["visual"], e["audio"]); },
-                    defaultLength = 8f,
+                    defaultLength = 7f,
                     resizable = true,
                     parameters = new List<Param>()
                     {
-                        new Param("auto", true, "Auto Pass Turn"),
+                        new Param("auto", true, "Auto Pass Turn", "", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "sound", "con", "visual", "audio" })
+                        }),
                         new Param("sound", true, "Play Time-Up Sound?", "Should the Time-Up sound play at the end of the interval?"),
                         new Param("con", false, "Consecutive", "Disables everything that happens at the end of the interval if ticked on."),
                         new Param("visual", true, "Stopwatch (Visual)", "Should the stopwatch visually appear?"),
@@ -60,7 +63,8 @@ namespace HeavenStudio.Games.Loaders
                         new Param("con", false, "Consecutive", "Disables everything that happens at the end of the interval if ticked on."),
                         new Param("visual", true, "Stopwatch (Visual)", "Should the stopwatch visually appear?"),
                         new Param("audio", QuizShow.ClockAudio.Both, "Stopwatch (Audio)", "Should the sounds of the stopwatch play?")
-                    }
+                    },
+                    resizable = true
                 },
                 new GameAction("revealAnswer", "Reveal Answer")
                 {
@@ -471,7 +475,7 @@ namespace HeavenStudio.Games
 
             if (autoPassTurn)
             {
-                PassTurn(beat + interval, beat, interval, timeUpSound, consecutive, visualClock, audioClock);
+                PassTurn(beat + interval, beat, interval, timeUpSound, consecutive, visualClock, audioClock, 1);
             }
         }
 
@@ -508,15 +512,16 @@ namespace HeavenStudio.Games
         private void PassTurnStandalone(double beat, bool timeUpSound, bool consecutive, bool visualClock, int audioClock)
         {
             var lastInterval = GetLastIntervalBeforeBeat(beat);
+            float length = EventCaller.GetAllInGameManagerList("quizShow", new string[] { "passTurn" }).Find(x => x.beat == beat).length;
             if (lastInterval != null)
             {
-                PassTurn(beat, lastInterval.beat, lastInterval.length, timeUpSound, consecutive, visualClock, audioClock);
+                PassTurn(beat, lastInterval.beat, lastInterval.length, timeUpSound, consecutive, visualClock, audioClock, length);
             }
         }
 
-        private void PassTurn(double beat, double intervalBeat, float intervalLength, bool timeUpSound, bool consecutive, bool visualClock, int audioClock)
+        private void PassTurn(double beat, double intervalBeat, float intervalLength, bool timeUpSound, bool consecutive, bool visualClock, int audioClock, float length)
         {
-            playerStartBeat = beat + 1;
+            playerStartBeat = beat + length;
             playerLength = intervalLength;
             var relevantInputs = GetInputsBetweenBeat(intervalBeat, intervalBeat + intervalLength);
             relevantInputs.Sort((x, y) => x.beat.CompareTo(y.beat));
@@ -527,11 +532,11 @@ namespace HeavenStudio.Games
                 bool isDpad = relevantInputs[i].datamodel == "quizShow/dPad";
                 if (isDpad)
                 {
-                    ScheduleAutoplayInput(beat, 1 + inputBeat, InputType.DIRECTION_DOWN, AutoplayDPad, Nothing, Nothing);
+                    ScheduleAutoplayInput(beat, length + inputBeat, InputType.DIRECTION_DOWN, AutoplayDPad, Nothing, Nothing);
                 }
                 else
                 {
-                    ScheduleAutoplayInput(beat, 1 + inputBeat, InputType.STANDARD_DOWN, AutoplayAButton, Nothing, Nothing);
+                    ScheduleAutoplayInput(beat, length + inputBeat, InputType.STANDARD_DOWN, AutoplayAButton, Nothing, Nothing);
                 }
             }
 
@@ -573,10 +578,10 @@ namespace HeavenStudio.Games
                     if (visualClock)
                     {
                         spawnedTimer.gameObject.SetActive(true);
-                        spawnedTimer.Init(beat + 1, intervalLength);
+                        spawnedTimer.Init(beat + length, intervalLength);
                     }
                 }),
-                new BeatAction.Action(beat + 1 + intervalLength, delegate
+                new BeatAction.Action(beat + length + intervalLength, delegate
                 {
                     if (!consecutive)
                     {
@@ -588,7 +593,7 @@ namespace HeavenStudio.Games
                     if (visualClock) Destroy(spawnedTimer.gameObject);
                 }
             ),
-                new BeatAction.Action(beat + 1 + intervalLength + timeUpBeat, delegate { if (timeUpSound && !consecutive) SoundByte.PlayOneShotGame("quizShow/timeUp"); }),
+                new BeatAction.Action(beat + length + intervalLength + timeUpBeat, delegate { if (timeUpSound && !consecutive) SoundByte.PlayOneShotGame("quizShow/timeUp"); }),
             };
             BeatAction.New(instance.gameObject, actions);
         }

--- a/Assets/Scripts/Games/SeeSaw/SeeSaw.cs
+++ b/Assets/Scripts/Games/SeeSaw/SeeSaw.cs
@@ -19,7 +19,10 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 4f,
                     parameters = new List<Param>()
                     {
-                        new Param("high", false, "High", "Will they perform high jumps?"),
+                        new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                        }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
                     }
@@ -30,7 +33,10 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 3f,
                     parameters = new List<Param>()
                     {
-                        new Param("high", false, "High", "Will they perform high jumps?"),
+                        new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                        }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
                     }
@@ -41,7 +47,10 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 3f,
                     parameters = new List<Param>()
                     {
-                        new Param("high", false, "High", "Will they perform high jumps?"),
+                        new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                        }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
                     }
@@ -52,7 +61,10 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 2f,
                     parameters = new List<Param>()
                     {
-                        new Param("high", false, "High", "Will they perform high jumps?"),
+                        new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                        }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
                     }

--- a/Assets/Scripts/Games/SeeSaw/SeeSawGuy.cs
+++ b/Assets/Scripts/Games/SeeSaw/SeeSawGuy.cs
@@ -142,6 +142,7 @@ namespace HeavenStudio.Games.Scripts_SeeSaw
                         transform.position = GetPathPositionFromBeat(currentPath, Math.Max(startBeat, currentBeat), startBeat);
                         break;
                 }
+                float newCamY = 0f;
                 if (!see && game.cameraMove)
                 {
                     switch (currentState)
@@ -152,11 +153,11 @@ namespace HeavenStudio.Games.Scripts_SeeSaw
                         case JumpState.HighOutIn:
                         case JumpState.HighInOut:
                         case JumpState.HighInIn:
-                            float newCamY = Math.Max(GetPathPositionFromBeat(cameraPath, Math.Max(startBeat, currentBeat), startBeat).y, 0);
-                            gameTrans.localPosition = new Vector3(0, -newCamY, 0);
+                            newCamY = Math.Max(GetPathPositionFromBeat(cameraPath, Math.Max(startBeat, currentBeat), startBeat).y, 0);
                             break;
                     }
                 }
+                gameTrans.localPosition = new Vector3(0, -newCamY, 0);
             }
         }
 

--- a/Assets/Scripts/Games/Tambourine/Tambourine.cs
+++ b/Assets/Scripts/Games/Tambourine/Tambourine.cs
@@ -16,7 +16,7 @@ namespace HeavenStudio.Games.Loaders
                 new GameAction("beat intervals", "Start Interval")
                 {
                     preFunction = delegate {var e = eventCaller.currentEntity; Tambourine.PreInterval(e.beat, e.length, e["auto"]); },
-                    defaultLength = 8f,
+                    defaultLength = 7f,
                     resizable = true,
                     parameters = new List<Param>()
                     {
@@ -37,7 +37,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         Tambourine.PrePassTurn(eventCaller.currentEntity.beat);
                     },
-                    defaultLength = 1f,
+                    resizable = true,
                     preFunctionLength = 1f
                 },
                 new GameAction("bop", "Bop")
@@ -260,7 +260,7 @@ namespace HeavenStudio.Games
 
             if (autoPassTurn)
             {
-                PassTurn(beat + interval, beat, interval);
+                PassTurn(beat + interval, beat, interval, 1);
             }
         }
 
@@ -300,10 +300,11 @@ namespace HeavenStudio.Games
         private void PassTurnStandalone(double beat)
         {
             var lastInterval = GetLastIntervalBeforeBeat(beat);
-            if (lastInterval != null) PassTurn(beat, lastInterval.beat, lastInterval.length);
+            float length = EventCaller.GetAllInGameManagerList("tambourine", new string[] { "pass turn" }).Find(x => x.beat == beat).length;
+            if (lastInterval != null) PassTurn(beat, lastInterval.beat, lastInterval.length, length);
         }
 
-        private void PassTurn(double beat, double intervalBeat, float intervalLength)
+        private void PassTurn(double beat, double intervalBeat, float intervalLength, float length)
         {
             SoundByte.PlayOneShotGame($"tambourine/monkey/turnPass/{UnityEngine.Random.Range(1, 6)}", beat);
             List<BeatAction.Action> actions = new()
@@ -323,9 +324,9 @@ namespace HeavenStudio.Games
                 double inputBeat = relevantInputs[i].beat - intervalBeat;
                 actions.Add(new BeatAction.Action(inputBeat, delegate
                 {
-                    if (isHit) ScheduleInput(beat + 1, inputBeat, InputType.STANDARD_ALT_DOWN, JustHit, Miss, Nothing);
-                    else ScheduleInput(beat + 1, inputBeat, InputType.STANDARD_DOWN, JustShake, Miss, Nothing);
-                    Bop(beat + 1 + inputBeat, 1, (int)WhoBops.Monkey, (int)WhoBops.None);
+                    if (isHit) ScheduleInput(beat + length, inputBeat, InputType.STANDARD_ALT_DOWN, JustHit, Miss, Nothing);
+                    else ScheduleInput(beat + length, inputBeat, InputType.STANDARD_DOWN, JustShake, Miss, Nothing);
+                    Bop(beat + length + inputBeat, 1, (int)WhoBops.Monkey, (int)WhoBops.None);
                 }));
             }
             BeatAction.New(gameObject, actions);

--- a/Assets/Scripts/Games/TapTrial/TapTrial.cs
+++ b/Assets/Scripts/Games/TapTrial/TapTrial.cs
@@ -56,7 +56,10 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 1f,
                     parameters = new List<Param>()
                     {
-                        new Param("toggle", true, "Scroll FX", "Will scroll"),
+                        new Param("toggle", true, "Scroll FX", "Will scroll", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "flash", "m"})
+                        }),
                         new Param("flash", true, "Flash FX", "Will flash to white"),
                         new Param("m", new EntityTypes.Float(0, 10, 1), "Speed Multiplier")
                     }

--- a/Assets/Scripts/Games/TapTroupe/TapTroupe.cs
+++ b/Assets/Scripts/Games/TapTroupe/TapTroupe.cs
@@ -31,9 +31,15 @@ namespace HeavenStudio.Games.Loaders
                     resizable = true,
                     parameters = new List<Param>()
                     {
-                        new Param("okay", true, "Okay Voice Line", "Whether or not the tappers should say -Okay!- after successfully tapping."),
+                        new Param("okay", true, "Okay Voice Line", "Whether or not the tappers should say -Okay!- after successfully tapping.", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (bool)x, new string[] { "okayType" })
+                        }),
                         new Param("okayType", TapTroupe.OkayType.OkayA, "Okay Type", "Which version of the okay voice line should the tappers say?"),
-                        new Param("animType", TapTroupe.OkayAnimType.Normal, "Okay Animation", "Which animations should be played when the tapper say OK?"),
+                        new Param("animType", TapTroupe.OkayAnimType.Normal, "Okay Animation", "Which animations should be played when the tapper say OK?", new List<Param.CollapseParam>()
+                        {
+                            new Param.CollapseParam(x => (int)x == (int)TapTroupe.OkayAnimType.Popper, new string[]{ "popperBeats"})
+                        }),
                         new Param("popperBeats", new EntityTypes.Float(0f, 80f, 2f), "Popper Beats", "How many beats until the popper will pop?"),
                         new Param("randomVoiceLine", true, "Extra Random Voice Line", "Whether there should be randomly said woos or laughs after the tappers say OK!"),
                         new Param("noReady", false, "Mute Ready")

--- a/Assets/Scripts/LevelEditor/EventSelector/EventParameterManager.cs
+++ b/Assets/Scripts/LevelEditor/EventSelector/EventParameterManager.cs
@@ -105,9 +105,12 @@ namespace HeavenStudio.Editor
                     ePrefabs.Add(propertyName, AddParam(propertyName, param, caption, tooltip));
                 }
 
+                Debug.Log(action.parameters);
+
                 foreach (var p in action.parameters)
                 {
-                    if (p.collapseParams == null) return;
+                    Debug.Log(p.collapseParams);
+                    if (p.collapseParams == null || p.collapseParams.Count == 0) continue;
                     EventPropertyPrefab input = ePrefabs[p.propertyName].GetComponent<EventPropertyPrefab>();
                     foreach (var c in p.collapseParams)
                     {


### PR DESCRIPTION
Call And Response Games:
- Games that have a signal before the player turn (quiz show, tambourine, second contact) now have stretchable pass turns again.

Lockstep:
- Made force stepping functional with onbeat/offbeat switch blocks
- Added standalone "Hai" and "Ho" blocks

Seesaw:
- Fixed a bug where the camera would not be at position (0, 0) in manual play when sometimes pressing early

Misc:
- Added some more collapseable properties, the ones for crop stomp and catchy tune don't work on my end for some reason, and i have no idea why, maybe it's onedrive? But it definitely feels like it's an issue on my end. Please tell me if they work on ur end