### PR TITLE
Collapsing Properties Update + Animation From Beat Method

### DIFF
--- a/Assets/Resources/Games/forkLifter.prefab
+++ b/Assets/Resources/Games/forkLifter.prefab
@@ -1119,7 +1119,6 @@ MonoBehaviour:
   SoundSequences: []
   EligibleHits: []
   scheduledInputs: []
-  firstEnable: 0
   ForkLifterHand: {fileID: 5813499711174113249}
   handAnim: {fileID: 5813499711174113250}
   flickedObject: {fileID: 5813499710694194086}

--- a/Assets/Resources/Sprites/Games/ForkLifter/Animations/Hand.controller
+++ b/Assets/Resources/Sprites/Games/ForkLifter/Animations/Hand.controller
@@ -26,55 +26,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-2244942594801115525
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -3335095768559015400}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1102 &-1603142614781995660
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: Hand_GrabObject
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -2244942594801115525}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 37f53717e1d7fc64898c793f83020828, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -97,28 +48,6 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
---- !u!1101 &2613062273872111154
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions: []
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -1603142614781995660}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
 --- !u!1102 &4663746626472684145
 AnimatorState:
   serializedVersion: 6
@@ -156,13 +85,10 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 6004606327514597299}
-    m_Position: {x: 520, y: 10, z: 0}
+    m_Position: {x: 520, y: 40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3335095768559015400}
-    m_Position: {x: 240, y: -10, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: -1603142614781995660}
-    m_Position: {x: 360, y: 120, z: 0}
+    m_Position: {x: 190, y: 210, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 4663746626472684145}
     m_Position: {x: 440, y: -70, z: 0}
@@ -189,8 +115,7 @@ AnimatorState:
   m_Name: Hand_Flick
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 2613062273872111154}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Resources/Sprites/Games/ForkLifter/Animations/Hand_Flick.anim
+++ b/Assets/Resources/Sprites/Games/ForkLifter/Animations/Hand_Flick.anim
@@ -19,22 +19,6 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: {x: 0, y: 0, z: -133.353}
-        inSlope: {x: Infinity, y: 0, z: 0}
-        outSlope: {x: Infinity, y: 0, z: 0}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0, y: 0.33333334, z: 0.33333334}
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    path: SOME01_128091f1_6_11
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
         value: {x: 0, y: 0, z: -133.452}
         inSlope: {x: Infinity, y: 0, z: 0}
         outSlope: {x: Infinity, y: 0, z: 0}
@@ -47,31 +31,6 @@ AnimationClip:
       m_RotationOrder: 4
     path: HandVisual
   m_PositionCurves:
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: {x: -0.363, y: 1.035, z: 74.52776}
-        inSlope: {x: Infinity, y: Infinity, z: Infinity}
-        outSlope: {x: Infinity, y: Infinity, z: Infinity}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-      - serializedVersion: 3
-        time: 0.16666667
-        value: {x: -0.218, y: 1.214, z: 74.52776}
-        inSlope: {x: Infinity, y: Infinity, z: Infinity}
-        outSlope: {x: Infinity, y: Infinity, z: Infinity}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    path: SOME01_128091f1_6_11
   - curve:
       serializedVersion: 2
       m_Curve:
@@ -93,10 +52,78 @@ AnimationClip:
         weightedMode: 0
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.3
+        value: {x: -0.235, y: 1.216, z: 74.52776}
+        inSlope: {x: Infinity, y: Infinity, z: Infinity}
+        outSlope: {x: Infinity, y: Infinity, z: Infinity}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.35
+        value: {x: -0.113, y: 1.145, z: 74.52776}
+        inSlope: {x: Infinity, y: Infinity, z: Infinity}
+        outSlope: {x: Infinity, y: Infinity, z: Infinity}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.4
+        value: {x: 0.02943516, y: 1.231121, z: 74.52776}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     path: HandVisual
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.3
+        value: {x: -0.1, y: 0.408, z: 74.52776}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.35
+        value: {x: 0.017, y: 0.261, z: 74.52776}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: PeaVisual
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.4
+        value: {x: 0.271, y: -0.031, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: HandVisual/hand_shadow1
   m_ScaleCurves: []
   m_FloatCurves:
   - curve:
@@ -113,6 +140,15 @@ AnimationClip:
         outWeight: 0
       - serializedVersion: 3
         time: 0.016666668
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 0.4
         value: 0
         inSlope: Infinity
         outSlope: Infinity
@@ -139,6 +175,15 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.3
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -149,41 +194,53 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: e289120f53cab0c47bc168c74f1334fe, type: 3}
+      value: {fileID: 0}
     - time: 0.016666668
-      value: {fileID: 21300000, guid: 7eac82b47cfe63d4a82e79916b6df821, type: 3}
+      value: {fileID: 0}
     - time: 0.033333335
-      value: {fileID: 21300000, guid: b577af31fb7acae469a736e54886426b, type: 3}
+      value: {fileID: 0}
     - time: 0.05
-      value: {fileID: 21300000, guid: bf6d6375d442f534cae6f4bf6da54243, type: 3}
+      value: {fileID: 0}
     - time: 0.06666667
-      value: {fileID: 21300000, guid: 2f97f62820af55c4f8fc0303ea6843f5, type: 3}
+      value: {fileID: 0}
     - time: 0.083333336
-      value: {fileID: 21300000, guid: 1a8c5fd3822226249957fa3356b4070a, type: 3}
+      value: {fileID: 0}
     - time: 0.1
-      value: {fileID: 21300000, guid: 4ed7ed944f9b66441941effac0f1806e, type: 3}
+      value: {fileID: 0}
     - time: 0.11666667
-      value: {fileID: 21300000, guid: a77ebd0aaac183e45bff0d05745cf0d1, type: 3}
+      value: {fileID: 0}
     - time: 0.13333334
-      value: {fileID: 21300000, guid: e8f0b0c90828def458b07adedcb16992, type: 3}
+      value: {fileID: 0}
     - time: 0.15
-      value: {fileID: 21300000, guid: 03f01dcf91cdae34897562741c338bcb, type: 3}
+      value: {fileID: 0}
     - time: 0.16666667
-      value: {fileID: 21300000, guid: 89164a5ca38e87d409b45d2a3c29de7c, type: 3}
+      value: {fileID: 0}
     - time: 0.18333334
-      value: {fileID: 21300000, guid: 200499fa2c79f214681c681dd0eaabd3, type: 3}
+      value: {fileID: 0}
     - time: 0.2
-      value: {fileID: 21300000, guid: fb1703ab0ff9d3c49a902548ce45ff91, type: 3}
+      value: {fileID: 0}
     - time: 0.21666667
-      value: {fileID: 21300000, guid: 809df09db346d6f4fb2aac15956b5d76, type: 3}
+      value: {fileID: 0}
     - time: 0.23333333
-      value: {fileID: 21300000, guid: f97227717c214104fa945ca47aa29617, type: 3}
+      value: {fileID: 0}
     - time: 0.25
-      value: {fileID: 21300000, guid: 8fe446d26cf43724196c575595c7dac4, type: 3}
+      value: {fileID: 0}
     - time: 0.26666668
-      value: {fileID: 21300000, guid: 8e9a1a3e172609848916109938ac8c53, type: 3}
+      value: {fileID: 0}
     - time: 0.28333333
-      value: {fileID: 21300000, guid: 20954ee1a93cedb498a429fcc1ea1fd7, type: 3}
+      value: {fileID: 0}
+    - time: 0.3
+      value: {fileID: 0}
+    - time: 0.31666666
+      value: {fileID: 0}
+    - time: 0.33333334
+      value: {fileID: 0}
+    - time: 0.35
+      value: {fileID: 0}
+    - time: 0.36666667
+      value: {fileID: 0}
+    - time: 0.38333333
+      value: {fileID: 0}
     attribute: m_Sprite
     path: Fork_Lifter_Gameplay
     classID: 212
@@ -193,14 +250,7 @@ AnimationClip:
       value: {fileID: -4922902375269903740, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
     - time: 0.16666667
       value: {fileID: -3456084564025576355, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
-    attribute: m_Sprite
-    path: SOME01_128091f1_6_11
-    classID: 212
-    script: {fileID: 0}
-  - curve:
-    - time: 0
-      value: {fileID: -4922902375269903740, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
-    - time: 0.16666667
+    - time: 0.4
       value: {fileID: -3456084564025576355, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
     attribute: m_Sprite
     path: HandVisual
@@ -223,13 +273,6 @@ AnimationClip:
   m_ClipBindingConstant:
     genericBindings:
     - serializedVersion: 2
-      path: 3316808799
-      attribute: 1
-      script: {fileID: 0}
-      typeID: 4
-      customType: 0
-      isPPtrCurve: 0
-    - serializedVersion: 2
       path: 3267382320
       attribute: 1
       script: {fileID: 0}
@@ -237,11 +280,11 @@ AnimationClip:
       customType: 0
       isPPtrCurve: 0
     - serializedVersion: 2
-      path: 3316808799
-      attribute: 4
+      path: 2083950812
+      attribute: 1
       script: {fileID: 0}
       typeID: 4
-      customType: 4
+      customType: 0
       isPPtrCurve: 0
     - serializedVersion: 2
       path: 3267382320
@@ -272,13 +315,6 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     - serializedVersion: 2
-      path: 3316808799
-      attribute: 0
-      script: {fileID: 0}
-      typeID: 212
-      customType: 23
-      isPPtrCurve: 1
-    - serializedVersion: 2
       path: 3267382320
       attribute: 0
       script: {fileID: 0}
@@ -292,28 +328,40 @@ AnimationClip:
       typeID: 212
       customType: 23
       isPPtrCurve: 1
+    - serializedVersion: 2
+      path: 3526390209
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
     pptrCurveMapping:
-    - {fileID: 21300000, guid: e289120f53cab0c47bc168c74f1334fe, type: 3}
-    - {fileID: 21300000, guid: 7eac82b47cfe63d4a82e79916b6df821, type: 3}
-    - {fileID: 21300000, guid: b577af31fb7acae469a736e54886426b, type: 3}
-    - {fileID: 21300000, guid: bf6d6375d442f534cae6f4bf6da54243, type: 3}
-    - {fileID: 21300000, guid: 2f97f62820af55c4f8fc0303ea6843f5, type: 3}
-    - {fileID: 21300000, guid: 1a8c5fd3822226249957fa3356b4070a, type: 3}
-    - {fileID: 21300000, guid: 4ed7ed944f9b66441941effac0f1806e, type: 3}
-    - {fileID: 21300000, guid: a77ebd0aaac183e45bff0d05745cf0d1, type: 3}
-    - {fileID: 21300000, guid: e8f0b0c90828def458b07adedcb16992, type: 3}
-    - {fileID: 21300000, guid: 03f01dcf91cdae34897562741c338bcb, type: 3}
-    - {fileID: 21300000, guid: 89164a5ca38e87d409b45d2a3c29de7c, type: 3}
-    - {fileID: 21300000, guid: 200499fa2c79f214681c681dd0eaabd3, type: 3}
-    - {fileID: 21300000, guid: fb1703ab0ff9d3c49a902548ce45ff91, type: 3}
-    - {fileID: 21300000, guid: 809df09db346d6f4fb2aac15956b5d76, type: 3}
-    - {fileID: 21300000, guid: f97227717c214104fa945ca47aa29617, type: 3}
-    - {fileID: 21300000, guid: 8fe446d26cf43724196c575595c7dac4, type: 3}
-    - {fileID: 21300000, guid: 8e9a1a3e172609848916109938ac8c53, type: 3}
-    - {fileID: 21300000, guid: 20954ee1a93cedb498a429fcc1ea1fd7, type: 3}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     - {fileID: -4922902375269903740, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
     - {fileID: -3456084564025576355, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
-    - {fileID: -4922902375269903740, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
     - {fileID: -3456084564025576355, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
     - {fileID: 7562980635367501552, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
     - {fileID: -1164378328580708214, guid: 52117e1d5cd298c42adfea952676c7d6, type: 3}
@@ -322,7 +370,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.3
+    m_StopTime: 0.4166667
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -343,147 +391,6 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: -0.363
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.16666667
-        value: -0.218
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.x
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1.035
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.16666667
-        value: 1.214
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.y
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 74.52776
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 0.16666667
-        value: 74.52776
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalPosition.z
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: localEulerAnglesRaw.x
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 0
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: localEulerAnglesRaw.y
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: -133.353
-        inSlope: Infinity
-        outSlope: Infinity
-        tangentMode: 103
-        weightedMode: 0
-        inWeight: 0
-        outWeight: 0
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: localEulerAnglesRaw.z
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
         value: -0.342
         inSlope: Infinity
         outSlope: Infinity
@@ -497,6 +404,33 @@ AnimationClip:
         inSlope: Infinity
         outSlope: Infinity
         tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.3
+        value: -0.235
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.35
+        value: -0.113
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.4
+        value: 0.02943516
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
@@ -528,6 +462,33 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.3
+        value: 1.216
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.35
+        value: 1.145
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.4
+        value: 1.231121
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -553,6 +514,33 @@ AnimationClip:
         inSlope: Infinity
         outSlope: Infinity
         tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.3
+        value: 74.52776
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.35
+        value: 74.52776
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.4
+        value: 74.52776
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
@@ -641,6 +629,15 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.4
+        value: 0
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -660,12 +657,162 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0
         outWeight: 0
+      - serializedVersion: 3
+        time: 0.3
+        value: 1
+        inSlope: Infinity
+        outSlope: Infinity
+        tangentMode: 103
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
     attribute: m_IsActive
     path: PeaVisual
     classID: 1
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.3
+        value: -0.1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.35
+        value: 0.017
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: PeaVisual
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.3
+        value: 0.408
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.35
+        value: 0.261
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: PeaVisual
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.3
+        value: 74.52776
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.35
+        value: 74.52776
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: PeaVisual
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.4
+        value: 0.271
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: HandVisual/hand_shadow1
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.4
+        value: -0.031
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: HandVisual/hand_shadow1
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0.4
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: HandVisual/hand_shadow1
+    classID: 4
     script: {fileID: 0}
   m_EulerEditorCurves:
   - curve:
@@ -674,37 +821,7 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_LocalEulerAngles.x
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve: []
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalEulerAngles.y
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve: []
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
     attribute: m_LocalEulerAngles.z
-    path: SOME01_128091f1_6_11
-    classID: 4
-    script: {fileID: 0}
-  - curve:
-      serializedVersion: 2
-      m_Curve: []
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    attribute: m_LocalEulerAngles.x
     path: HandVisual
     classID: 4
     script: {fileID: 0}
@@ -724,7 +841,7 @@ AnimationClip:
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
-    attribute: m_LocalEulerAngles.z
+    attribute: m_LocalEulerAngles.x
     path: HandVisual
     classID: 4
     script: {fileID: 0}

--- a/Assets/Scripts/Games/AirRally/AirRally.cs
+++ b/Assets/Scripts/Games/AirRally/AirRally.cs
@@ -190,7 +190,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("enable", true, "Enable", "", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "main", "side", "speed", "endSpeed", "ease" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "main", "side", "speed", "endSpeed", "ease" })
                         }),
                         new Param("main", new EntityTypes.Integer(0, 300, 50), "Main Trees", "How many trees per second?"),
                         new Param("side", new EntityTypes.Integer(0, 100, 30), "Side Trees", "How many trees per second?"),

--- a/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
+++ b/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
@@ -24,7 +24,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("silent", false, "Mute Audio", "Whether the piano notes should be muted or not.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => !(bool)x, new string[] { "note1", "note2", "note3", "note4", "note5", "note6"})
+                            new Param.CollapseParam((x, _) => !(bool)x, new string[] { "note1", "note2", "note3", "note4", "note5", "note6"})
                         }),
                         new Param("note1", new EntityTypes.Integer(-24, 24, 0), "1st note", "The number of semitones up or down this note should be pitched"),
                         new Param("note2", new EntityTypes.Integer(-24, 24, 2), "2nd note", "The number of semitones up or down this note should be pitched"),

--- a/Assets/Scripts/Games/CatchyTune/CatchyTune.cs
+++ b/Assets/Scripts/Games/CatchyTune/CatchyTune.cs
@@ -22,7 +22,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("side", CatchyTune.Side.Left, "Side", "The side the orange falls down"),
                         new Param("smile", false, "Smile", "If the characters smile with the heart message after catching", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "endSmile" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "endSmile" })
                         }),
                         new Param("endSmile", new EntityTypes.Float(2, 100, 2), "End Smile Beat", "How many beats after the catch should the smile end?")
                     },
@@ -37,7 +37,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("side", CatchyTune.Side.Left, "Side", "The side the pineapple falls down"),
                         new Param("smile", false, "Smile", "If the characters smile with the heart message after catching", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "endSmile" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "endSmile" })
                         }),
                         new Param("endSmile", new EntityTypes.Float(2, 100, 2), "End Smile Beat", "How many beats after the catch should the smile end?")
                     },

--- a/Assets/Scripts/Games/CropStomp/CropStomp.cs
+++ b/Assets/Scripts/Games/CropStomp/CropStomp.cs
@@ -57,7 +57,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("limit", new EntityTypes.Integer(1, 1000, 80), "Limit", "What is the limit for plants collected?"),
                         new Param("force", false, "Force Amount of Collected Plants", "", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "forceAmount" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "forceAmount" })
                         }),
                         new Param("forceAmount", new EntityTypes.Integer(0, 1000, 0), "Force Amount")
                     }

--- a/Assets/Scripts/Games/DrummingPractice/DrummingPractice.cs
+++ b/Assets/Scripts/Games/DrummingPractice/DrummingPractice.cs
@@ -41,7 +41,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("toggle", false, "Set All to Player", "Sets all Miis to the Player's Mii", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => !(bool)x, new string[] { "type", "type2", "type3" })
+                            new Param.CollapseParam((x, _) => !(bool)x, new string[] { "type", "type2", "type3" })
                         }),
                         new Param("type", DrummingPractice.MiiType.Random, "Player Mii", "The Mii that the player will control"),
                         new Param("type2", DrummingPractice.MiiType.Random, "Left Mii", "The Mii on the left"),

--- a/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
+++ b/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
@@ -59,12 +59,12 @@ namespace HeavenStudio.Games.Loaders
                         new Param("uh", new EntityTypes.Integer(0, 3, 0), "Uh Count", "How many Uhs should Captain Tuck say after the flippers roll?"),
                         new Param("appreciation", FlipperFlop.AppreciationType.None, "Appreciation", "Which appreciation line should Captain Tuck say?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x != (int)FlipperFlop.AppreciationType.None, new string[] { "heart" })
+                            new Param.CollapseParam((x, _) => (int)x != (int)FlipperFlop.AppreciationType.None, new string[] { "heart" })
                         }),
                         new Param("heart", false, "Hearts", "Should Captain Tuck blush and make hearts appear when he expresses his appreciation?"),
                         new Param("thatsIt", false, "That's it!", "Whether or not Captain Tuck should say -That's it!- on the final flipper roll.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "barber" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "barber" })
                         }),
                         new Param("barber", false, "Barbershop that's it variant", "Should captain tuck use the Barbershop remix variant of that's it?")
                     },

--- a/Assets/Scripts/Games/ForkLifter/ForkLifter.cs
+++ b/Assets/Scripts/Games/ForkLifter/ForkLifter.cs
@@ -16,7 +16,8 @@ namespace HeavenStudio.Games.Loaders
                 {
                     function = delegate {
                         var e = eventCaller.currentEntity;
-                        ForkLifter.instance.Flick(e.beat, e["type"]);
+                        ForkLifter.Flick(e.beat);
+                        ForkLifter.instance.FlickActive(e.beat, e["type"]);
                     },
                     defaultLength = 3,
                     parameters = new List<Param>()
@@ -25,8 +26,8 @@ namespace HeavenStudio.Games.Loaders
                     },
                     inactiveFunction = delegate {
                         var e = eventCaller.currentEntity;
+                        ForkLifter.Flick(e.beat);
                         ForkLifter.queuedFlicks.Add(e);
-                        ForkLifter.instance.Flick(e.beat, e["type"]);
                     },
                 },
                 new GameAction("prepare", "Prepare Hand")
@@ -137,7 +138,7 @@ namespace HeavenStudio.Games
         {
             base.OnGameSwitch(beat);
             if (queuedFlicks.Count > 0) {
-                foreach (var flick in queuedFlicks) { FlickActive(flick.beat, flick["type"], beat - flick.beat); }
+                foreach (var flick in queuedFlicks) { FlickActive(flick.beat, flick["type"]); }
                 queuedFlicks.Clear();
             }
 
@@ -159,23 +160,18 @@ namespace HeavenStudio.Games
             }
         }
 
-        public void Flick(double beat, int type, double currentBeat = 0)
+        public static void Flick(double beat)
         {
-            SoundByte.PlayOneShotGame("forkLifter/flick");
-            handAnim.DoScaledAnimationFromBeatAsync("Hand_Flick", 0.5f, beat, currentBeat);
-            ForkLifterHand.currentFlickIndex++;
-            GameObject fo = Instantiate(flickedObject);
-            fo.transform.parent = flickedObject.transform.parent;
-            Pea pea = fo.GetComponent<Pea>();
-            pea.startBeat = beat;
-            pea.type = type;
-            fo.SetActive(true);
+            var offset = SoundByte.GetClipLengthGame("forkLifter/zoomFast") - 0.03;
+            SoundByte.PlayOneShotGame("forkLifter/zoomFast", beat + 2, offset: offset, forcePlay: true);
+
+            SoundByte.PlayOneShotGame("forkLifter/flick", forcePlay: true);
         }
 
-        public void FlickActive(double beat, int type, double currentBeat = 0)
+        public void FlickActive(double beat, int type)
         {
-            SoundByte.PlayOneShotGame("forkLifter/flick");
-            handAnim.DoScaledAnimationFromBeatAsync("Hand_Flick", 0.5f, beat, currentBeat);
+
+            handAnim.DoScaledAnimationFromBeatAsync("Hand_Flick", 0.5f, beat);
             ForkLifterHand.currentFlickIndex++;
             GameObject fo = Instantiate(flickedObject);
             fo.transform.parent = flickedObject.transform.parent;

--- a/Assets/Scripts/Games/ForkLifter/ForkLifter.cs
+++ b/Assets/Scripts/Games/ForkLifter/ForkLifter.cs
@@ -14,17 +14,29 @@ namespace HeavenStudio.Games.Loaders
             {
                 new GameAction("flick", "Flick Food")
                 {
-                    function = delegate { var e = eventCaller.currentEntity; ForkLifter.instance.Flick(e.beat, e["type"]); }, 
+                    function = delegate {
+                        var e = eventCaller.currentEntity;
+                        ForkLifter.instance.Flick(e.beat, e["type"]);
+                    },
                     defaultLength = 3,
                     parameters = new List<Param>()
                     {
                         new Param("type", ForkLifter.FlickType.Pea, "Object", "The object to be flicked")
-                    }
+                    },
+                    inactiveFunction = delegate {
+                        var e = eventCaller.currentEntity;
+                        ForkLifter.queuedFlicks.Add(e);
+                        ForkLifter.instance.Flick(e.beat, e["type"]);
+                    },
                 },
                 new GameAction("prepare", "Prepare Hand")
                 {
-                    function = delegate { ForkLifter.instance.ForkLifterHand.Prepare(); }, 
-                    defaultLength = 0.5f
+                    function = delegate { ForkLifter.instance.ForkLifterHand.Prepare(eventCaller.currentEntity["mute"]); }, 
+                    defaultLength = 0.5f,
+                    parameters = new List<Param>()
+                    {
+                        new Param("mute", false, "Mute Prepare")
+                    }
                 },
                 new GameAction("gulp", "Swallow")
                 {
@@ -32,7 +44,6 @@ namespace HeavenStudio.Games.Loaders
                 },
                 new GameAction("sigh", "Sigh")
                 {
-
                     function = delegate { SoundByte.PlayOneShot("games/forkLifter/sigh"); }
                 },
                 new GameAction("color", "Background Color")
@@ -67,32 +78,6 @@ namespace HeavenStudio.Games.Loaders
                     },
                     resizable = true,
                 },
-                
-                // These are still here for backwards-compatibility but are hidden in the editor
-                new GameAction("pea", "")
-                {
-                    function = delegate { ForkLifter.instance.Flick(eventCaller.currentEntity.beat, 0); }, 
-                    defaultLength = 3, 
-                    hidden = true
-                },
-                new GameAction("topbun", "")
-                {
-                    function = delegate { ForkLifter.instance.Flick(eventCaller.currentEntity.beat, 1); }, 
-                    defaultLength = 3, 
-                    hidden = true
-                },
-                new GameAction("burger", "")
-                {
-                    function = delegate { ForkLifter.instance.Flick(eventCaller.currentEntity.beat, 2); }, 
-                    defaultLength = 3, 
-                    hidden = true
-                },
-                new GameAction("bottombun", "")
-                {
-                    function = delegate { ForkLifter.instance.Flick(eventCaller.currentEntity.beat, 3); }, 
-                    defaultLength = 3, 
-                    hidden = true
-                },
             },
             new List<string>() {"rvl", "normal"},
             "rvlfork", "en",
@@ -104,10 +89,12 @@ namespace HeavenStudio.Games.Loaders
 
 namespace HeavenStudio.Games
 {
+    using Jukebox;
     using Scripts_ForkLifter;
 
     public class ForkLifter : Minigame
     {
+        public static List<RiqEntity> queuedFlicks = new();
 
         public enum FlickType
         {
@@ -149,27 +136,46 @@ namespace HeavenStudio.Games
         public override void OnGameSwitch(double beat)
         {
             base.OnGameSwitch(beat);
+            if (queuedFlicks.Count > 0) {
+                foreach (var flick in queuedFlicks) { FlickActive(flick.beat, flick["type"], beat - flick.beat); }
+                queuedFlicks.Clear();
+            }
+
+            ForkLifterHand.allFlickEntities = GameManager.instance.Beatmap.Entities.FindAll(c => (c.datamodel == "forkLifter/flick") && (c.beat >= beat));
             ForkLifterHand.CheckNextFlick();
             PersistColor(beat);
         }
 
-        
         public void Bop(double beat, double length, bool doesBop, bool autoBop)
         {
-            playerInstance.shouldBop = (autoBop || doesBop);
-            if (!autoBop && doesBop) {
-                BeatAction.New(this, new List<BeatAction.Action>() {
-                    new BeatAction.Action(beat + length, delegate {
-                        playerInstance.shouldBop = false;
-                    })
-                });
+            playerInstance.shouldBop = autoBop;
+            if (doesBop)
+            {
+                var actions = new List<BeatAction.Action>();
+                for (int i = 0; i < length; i++) {
+                    actions.Add(new(beat + i, delegate { playerInstance.SingleBop(); }));
+                }
+                BeatAction.New(playerInstance, actions);
             }
         }
 
-        public void Flick(double beat, int type)
+        public void Flick(double beat, int type, double currentBeat = 0)
         {
             SoundByte.PlayOneShotGame("forkLifter/flick");
-            handAnim.Play("Hand_Flick", 0, 0);
+            handAnim.DoScaledAnimationFromBeatAsync("Hand_Flick", 0.5f, beat, currentBeat);
+            ForkLifterHand.currentFlickIndex++;
+            GameObject fo = Instantiate(flickedObject);
+            fo.transform.parent = flickedObject.transform.parent;
+            Pea pea = fo.GetComponent<Pea>();
+            pea.startBeat = beat;
+            pea.type = type;
+            fo.SetActive(true);
+        }
+
+        public void FlickActive(double beat, int type, double currentBeat = 0)
+        {
+            SoundByte.PlayOneShotGame("forkLifter/flick");
+            handAnim.DoScaledAnimationFromBeatAsync("Hand_Flick", 0.5f, beat, currentBeat);
             ForkLifterHand.currentFlickIndex++;
             GameObject fo = Instantiate(flickedObject);
             fo.transform.parent = flickedObject.transform.parent;

--- a/Assets/Scripts/Games/ForkLifter/ForkLifterHand.cs
+++ b/Assets/Scripts/Games/ForkLifter/ForkLifterHand.cs
@@ -15,57 +15,32 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 
         public Sprite[] fastSprites;
 
-        private List<RiqEntity> allFlickEntities = new List<RiqEntity>();
+        public List<RiqEntity> allFlickEntities = new List<RiqEntity>();
 
         public int currentFlickIndex;
 
+        ForkLifter game;
+
         private void Awake()
         {
-            var flickEntities = EventCaller.GetAllInGameManagerList("forkLifter", new string[] { "flick" });
-            List<RiqEntity> tempEvents = new List<RiqEntity>();
-            for (int i = 0; i < flickEntities.Count; i++)
-            {
-                if (flickEntities[i].beat >= Conductor.instance.songPositionInBeatsAsDouble)
-                {
-                    tempEvents.Add(flickEntities[i]);
-                }
-            }
-            allFlickEntities = tempEvents;
+            game = ForkLifter.instance;
         }
 
         public void CheckNextFlick()
         {
             if (allFlickEntities.Count > 0 && currentFlickIndex >= 0 && currentFlickIndex < allFlickEntities.Count)
             {
-                switch (allFlickEntities[currentFlickIndex]["type"])
-                {
-                    case (int)ForkLifter.FlickType.Pea:
-                        ForkLifter.instance.peaPreview.sprite = ForkLifter.instance.peaSprites[0];
-                        fastSprite.sprite = fastSprites[0];
-                        break;
-                    case (int)ForkLifter.FlickType.TopBun:
-                        ForkLifter.instance.peaPreview.sprite = ForkLifter.instance.peaSprites[1];
-                        fastSprite.sprite = fastSprites[0];
-                        break;
-                    case (int)ForkLifter.FlickType.Burger:
-                        ForkLifter.instance.peaPreview.sprite = ForkLifter.instance.peaSprites[2];
-                        fastSprite.sprite = fastSprites[1];
-                        break;
-                    case (int)ForkLifter.FlickType.BottomBun:
-                        ForkLifter.instance.peaPreview.sprite = ForkLifter.instance.peaSprites[3];
-                        fastSprite.sprite = fastSprites[0];
-                        break;
-                }
-            }
-            else
-            {
-                ForkLifter.instance.peaPreview.sprite = null;
+                int nextType = allFlickEntities[currentFlickIndex]["type"];
+                game.peaPreview.sprite = game.peaSprites[nextType];
+                fastSprite.sprite = fastSprites[nextType == (int)ForkLifter.FlickType.Burger ? 1 : 0];
+            } else {
+                game.peaPreview.sprite = null;
             }
         }
 
-        public void Prepare()
+        public void Prepare(bool mute)
         {
-            SoundByte.PlayOneShotGame("forkLifter/flickPrepare");
+            if (!mute) SoundByte.PlayOneShotGame("forkLifter/flickPrepare");
             GetComponent<Animator>().Play("Hand_Prepare", 0, 0);
         }
     }

--- a/Assets/Scripts/Games/ForkLifter/ForkLifterPlayer.cs
+++ b/Assets/Scripts/Games/ForkLifter/ForkLifterPlayer.cs
@@ -57,8 +57,13 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 
             if (Conductor.instance.ReportBeat(ref lastReportedBeat) && anim.IsAnimationNotPlaying() && shouldBop) 
             {
-                anim.DoScaledAnimationAsync("Player_Bop", 0.5f);
+                SingleBop();
             }
+        }
+
+        public void SingleBop()
+        {
+            anim.DoScaledAnimationAsync("Player_Bop", 0.5f);
         }
 
         public void Eat()

--- a/Assets/Scripts/Games/ForkLifter/Pea.cs
+++ b/Assets/Scripts/Games/ForkLifter/Pea.cs
@@ -10,23 +10,22 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 {
     public class Pea : MonoBehaviour
     {
+        public double startBeat;
+        public int type;
+
         ForkLifter game;
+        ForkLifterPlayer player;
         private Animator anim;
 
-        public double startBeat;
-
-        public int type;
 
         private void Awake()
         {
             game = ForkLifter.instance;
+            player = ForkLifterPlayer.instance;
             anim = GetComponent<Animator>();
 
-            // SCHEDULING zoom sound so it lines up with when it meets the fork.
-            var currentDspTime = AudioSettings.dspTime;
-            var cond = Conductor.instance;
-            var zoomStartTime = currentDspTime + (cond.pitchedSecPerBeatAsDouble * 2) - 0.317;
-            SoundByte.PlayOneShotScheduledGame("forkLifter/zoomFast", zoomStartTime);
+            var offset = SoundByte.GetClipLengthGame("forkLifter/zoomFast") - 0.03;
+            SoundByte.PlayOneShotGame("forkLifter/zoomFast", startBeat + 2, offset: offset);
 
             GetComponentInChildren<SpriteRenderer>().sprite = game.peaSprites[type];
 
@@ -40,13 +39,13 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 
         public void Hit()
         {
-            ForkLifterPlayer.instance.Stab(this);
+            player.Stab(this);
 
-            if (ForkLifterPlayer.instance.currentPerfectPeasOnFork < 4)
+            if (player.currentPerfectPeasOnFork < 4)
             {
                 GameObject pea = new GameObject();
 
-                pea.transform.parent = ForkLifterPlayer.instance.perfect.transform;
+                pea.transform.parent = player.perfect.transform;
                 pea.transform.localScale = Vector2.one;
                 pea.transform.localRotation = Quaternion.Euler(0, 0, 0);
 
@@ -54,59 +53,42 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 
                 float peaOffset = 0;
 
-                if (ForkLifterPlayer.instance.currentPerfectPeasOnFork == 3) peaOffset = -0.15724f;
+                if (player.currentPerfectPeasOnFork == 3) peaOffset = -0.15724f;
 
-                for (int i = 0; i < ForkLifterPlayer.instance.perfect.transform.childCount; i++)
+                for (int i = 0; i < player.perfect.transform.childCount; i++)
                 {
-                    ForkLifterPlayer.instance.perfect.transform.GetChild(i).transform.localPosition = new Vector3(0, (-1.67f - (0.15724f * i)) + 0.15724f * ForkLifterPlayer.instance.currentPerfectPeasOnFork + peaOffset);
+                    player.perfect.transform.GetChild(i).transform.localPosition = new Vector3(0, (-1.67f - (0.15724f * i)) + 0.15724f * player.currentPerfectPeasOnFork + peaOffset);
                 }
 
                 SpriteRenderer psprite = pea.AddComponent<SpriteRenderer>();
+
                 psprite.sprite = game.peaHitSprites[type];
-                psprite.sortingOrder = 20;
-                switch (type)
-                {
-                    case 0:
-                        psprite.sortingOrder = 101;
-                        break;
-                    case 1:
-                        psprite.sortingOrder = 104;
-                        break;
-                    case 2:
-                        psprite.sortingOrder = 103;
-                        break;
-                    case 3:
-                        psprite.sortingOrder = 102;
-                        break;
-                }
+                psprite.sortingOrder = type switch {
+                    0 => 101,
+                    1 => 104,
+                    2 => 103,
+                    3 => 102,
+                    _ => 20,
+                };
             }
 
             GameObject hitFXo = new GameObject();
             hitFXo.transform.localPosition = new Vector3(1.9969f, -3.7026f);
             hitFXo.transform.localScale = new Vector3(3.142196f, 3.142196f);
             SpriteRenderer hfxs = hitFXo.AddComponent<SpriteRenderer>();
-            hfxs.sprite = ForkLifterPlayer.instance.hitFX;
+            hfxs.sprite = player.hitFX;
             hfxs.sortingOrder = 100;
             hfxs.DOColor(new Color(1, 1, 1, 0), 0.05f).OnComplete(delegate { Destroy(hitFXo); });
 
-            ForkLifterPlayer.instance.FastEffectHit(type);
+            player.FastEffectHit(type);
 
             SoundByte.PlayOneShotGame("forkLifter/stab");
 
-            ForkLifterPlayer.instance.currentPerfectPeasOnFork++;
+            player.currentPerfectPeasOnFork++;
 
-            if (type == 1)
-            {
-                ForkLifterPlayer.instance.topbun = true;
-            }
-            else if (type == 2)
-            {
-                ForkLifterPlayer.instance.middleburger = true;
-            }
-            else if (type == 3)
-            {
-                ForkLifterPlayer.instance.bottombun = true;
-            }
+            player.topbun = type == 1;
+            player.middleburger = type == 2;
+            player.bottombun = type == 3;
 
             Destroy(this.gameObject);
         }
@@ -115,30 +97,30 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
         {
             GameObject pea = new GameObject();
 
-            pea.transform.parent = ForkLifterPlayer.instance.early.transform;
+            pea.transform.parent = player.early.transform;
             pea.transform.localScale = Vector2.one;
 
             pea.transform.localPosition = Vector3.zero;
             pea.transform.localRotation = Quaternion.Euler(0, 0, 90);
 
-            for (int i = 0; i < ForkLifterPlayer.instance.early.transform.childCount; i++)
+            for (int i = 0; i < player.early.transform.childCount; i++)
             {
-                ForkLifterPlayer.instance.early.transform.GetChild(i).transform.localPosition = new Vector3(0, (-1.67f - (0.15724f * i)) + 0.15724f * ForkLifterPlayer.instance.currentEarlyPeasOnFork);
+                player.early.transform.GetChild(i).transform.localPosition = new Vector3(0, (-1.67f - (0.15724f * i)) + 0.15724f * player.currentEarlyPeasOnFork);
             }
 
             SpriteRenderer psprite = pea.AddComponent<SpriteRenderer>();
             psprite.sprite = game.peaHitSprites[type];
             psprite.sortingOrder = 20;
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(1.0424f, -4.032f), new Vector2(1.129612f, 1.129612f));
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(0.771f, -3.016f), new Vector2(1.71701f, 1.71701f));
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(2.598f, -2.956f), new Vector2(1.576043f, 1.576043f));
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(2.551f, -3.609f), new Vector2(1.200788f, 1.200788f));
+            player.HitFXMiss(new Vector2(1.0424f, -4.032f), new Vector2(1.129612f, 1.129612f));
+            player.HitFXMiss(new Vector2(0.771f, -3.016f), new Vector2(1.71701f, 1.71701f));
+            player.HitFXMiss(new Vector2(2.598f, -2.956f), new Vector2(1.576043f, 1.576043f));
+            player.HitFXMiss(new Vector2(2.551f, -3.609f), new Vector2(1.200788f, 1.200788f));
 
-            ForkLifterPlayer.instance.FastEffectHit(type);
+            player.FastEffectHit(type);
 
             SoundByte.PlayOneShot("miss");
 
-            ForkLifterPlayer.instance.currentEarlyPeasOnFork++;
+            player.currentEarlyPeasOnFork++;
 
             Destroy(this.gameObject);
         }
@@ -146,30 +128,30 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
         public void Late()
         {
             GameObject pea = new GameObject();
-            pea.transform.parent = ForkLifterPlayer.instance.late.transform;
+            pea.transform.parent = player.late.transform;
             pea.transform.localScale = Vector2.one;
 
             pea.transform.localPosition = Vector3.zero;
             pea.transform.localRotation = Quaternion.Euler(0, 0, 90);
 
-            for (int i = 0; i < ForkLifterPlayer.instance.late.transform.childCount; i++)
+            for (int i = 0; i < player.late.transform.childCount; i++)
             {
-                ForkLifterPlayer.instance.late.transform.GetChild(i).transform.localPosition = new Vector3(0, (-1.67f - (0.15724f * i)) + 0.15724f * ForkLifterPlayer.instance.currentLatePeasOnFork);
+                player.late.transform.GetChild(i).transform.localPosition = new Vector3(0, (-1.67f - (0.15724f * i)) + 0.15724f * player.currentLatePeasOnFork);
             }
 
             SpriteRenderer psprite = pea.AddComponent<SpriteRenderer>();
             psprite.sprite = game.peaHitSprites[type];
             psprite.sortingOrder = 20;
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(1.0424f, -4.032f), new Vector2(1.129612f, 1.129612f));
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(0.771f, -3.016f), new Vector2(1.71701f, 1.71701f));
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(2.598f, -2.956f), new Vector2(1.576043f, 1.576043f));
-            ForkLifterPlayer.instance.HitFXMiss(new Vector2(2.551f, -3.609f), new Vector2(1.200788f, 1.200788f));
+            player.HitFXMiss(new Vector2(1.0424f, -4.032f), new Vector2(1.129612f, 1.129612f));
+            player.HitFXMiss(new Vector2(0.771f, -3.016f), new Vector2(1.71701f, 1.71701f));
+            player.HitFXMiss(new Vector2(2.598f, -2.956f), new Vector2(1.576043f, 1.576043f));
+            player.HitFXMiss(new Vector2(2.551f, -3.609f), new Vector2(1.200788f, 1.200788f));
 
-            ForkLifterPlayer.instance.FastEffectHit(type);
+            player.FastEffectHit(type);
 
             SoundByte.PlayOneShot("miss");
 
-            ForkLifterPlayer.instance.currentLatePeasOnFork++;
+            player.currentLatePeasOnFork++;
             Destroy(this.gameObject);
         }
 
@@ -182,16 +164,11 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
 
         private void Just(PlayerActionEvent caller, float state)
         {
-            if (state >= 1f)
-            {
+            if (state >= 1f) {
                 Late();
-            } 
-            else if (state <= -1f) 
-            {
+            }  else if (state <= -1f) {
                 Early();
-            }
-            else
-            {
+            } else {
                 Hit();
             }
         }

--- a/Assets/Scripts/Games/ForkLifter/Pea.cs
+++ b/Assets/Scripts/Games/ForkLifter/Pea.cs
@@ -24,9 +24,6 @@ namespace HeavenStudio.Games.Scripts_ForkLifter
             player = ForkLifterPlayer.instance;
             anim = GetComponent<Animator>();
 
-            var offset = SoundByte.GetClipLengthGame("forkLifter/zoomFast") - 0.03;
-            SoundByte.PlayOneShotGame("forkLifter/zoomFast", startBeat + 2, offset: offset);
-
             GetComponentInChildren<SpriteRenderer>().sprite = game.peaSprites[type];
 
             for (int i = 0; i < transform.GetChild(0).childCount; i++)

--- a/Assets/Scripts/Games/GleeClub/GleeClub.cs
+++ b/Assets/Scripts/Games/GleeClub/GleeClub.cs
@@ -31,7 +31,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("close", GleeClub.MouthOpenClose.Both, "Close/Open Mouth", "Should the chorus kids close/open their mouth?"),
                         new Param("repeat", false, "Repeating", "Should the left and middle chorus kid repeat this singing cue?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "semiTonesLeft2", "semiTonesLeft3", "semiTonesMiddle2" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "semiTonesLeft2", "semiTonesLeft3", "semiTonesMiddle2" })
                         }),
                         new Param("semiTonesLeft2", new EntityTypes.Integer(-24, 24, 0), "Semitones (Repeat Left First)", "The number of semitones up or down this note should be pitched"),
                         new Param("semiTonesLeft3", new EntityTypes.Integer(-24, 24, 0), "Semitones (Repeat Left Last)", "The number of semitones up or down this note should be pitched"),

--- a/Assets/Scripts/Games/KarateMan/KarateMan.cs
+++ b/Assets/Scripts/Games/KarateMan/KarateMan.cs
@@ -143,14 +143,14 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("type", KarateMan.LightBulbType.Normal, "Type", "The preset bulb type. Yellow is used for kicks while Blue is used for combos", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)KarateMan.LightBulbType.Custom, new string[] { "colorA" })
+                            new Param.CollapseParam((x, _) => (int)x == (int)KarateMan.LightBulbType.Custom, new string[] { "colorA" })
                         }),
                         new Param("colorA", new Color(1f,1f,1f), "Custom Color", "The color to use when the bulb type is set to Custom"),
                         new Param("type2", KarateMan.KarateManFaces.Normal, "Success Expression", "The facial expression to set Joe to on hit"),
                         new Param("mute", false, "Mute", "Should the throwing sound be muted?"),
                         new Param("sfx", KarateMan.LightBulbSfx.Automatic, "SFX", "What type of SFX to use for the bulb?", new List<Param.CollapseParam>() 
                         {
-                            new Param.CollapseParam(x => (int)x == (int)KarateMan.LightBulbSfx.Custom, new string[] { "throwSfx", "hitSfx" }),
+                            new Param.CollapseParam((x, _) => (int)x == (int)KarateMan.LightBulbSfx.Custom, new string[] { "throwSfx", "hitSfx" }),
                         }),
                         new Param("throwSfx", "lightbulbOut", "Throw SFX", "Custom throw SFX to use for the bulb"),
                         new Param("hitSfx", "lightbulbHit", "Hit SFX", "Custom hit SFX to use for the bulb"),
@@ -176,7 +176,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("type", KarateMan.KarateManFaces.Smirk, "Success Expression", "The facial expression to set Joe to on hit"),
                         new Param("pitchVoice", false, "Pitch Voice", "Pitch the voice of this cue?", new List<Param.CollapseParam>() 
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "forcePitch" }),
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "forcePitch" }),
                         }),
                         new Param("forcePitch", new EntityTypes.Float(0.5f, 2f, 1f), "Force Pitch", "Override the automatic pitching if not set to 1"),
                         new Param("cutOut", true, "Cut Out Voice", "Will this cue be cut out by another voice?"),
@@ -203,7 +203,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("type", KarateMan.KarateManFaces.Happy, "Success Expression", "The facial expression to set Joe to on hit"),
                         new Param("pitchVoice", false, "Pitch Voice", "Pitch the voice of this cue?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "forcePitch" }),
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "forcePitch" }),
                         }),
                         new Param("forcePitch", new EntityTypes.Float(0.5f, 2f, 1f), "Force Pitch", "Override the automatic pitching if not set to 1"),
                         new Param("cutOut", true, "Cut Out Voice", "Will this cue be cut out by another voice?"),
@@ -221,11 +221,11 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>()
                     {
                         new Param("whichWarning", KarateMan.HitThree.HitThree, "Which Warning", "The warning text to show and the sfx to play"),
-                        new Param("pitchVoice", false, "Pitch Voice", "Pitch the voice of this cue?", new List<Param.CollapseParam>()
+                        new Param("pitchVoice", false, "Auto Pitch Voice", "Pitch the voice of this cue depending on the BPM", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "forcePitch" }),
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "forcePitch" }),
                         }),
-                        new Param("forcePitch", new EntityTypes.Float(0.5f, 2f, 1f), "Force Pitch", "Override the automatic pitching if not set to 1"),
+                        new Param("forcePitch", new EntityTypes.Float(0.5f, 2f, 1f), "Force Pitch", "Pitch the voice of this cue depending on the value"),
                         new Param("customLength", false, "Custom Length", "Have the warning text appear for the length of the block"),
                         new Param("cutOut", true, "Cut Out Voice", "Will this cue be cut out by another voice?"),
                     },
@@ -259,7 +259,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("fxType", KarateMan.BackgroundFXType.None, "FX Type", "The background effect to be displayed"),
                         new Param("type", KarateMan.NoriMode.None, "Flow Bar type", "The type of Flow bar to use", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x != (int)KarateMan.NoriMode.None, new string[] { "startColor" })
+                            new Param.CollapseParam((x, _) => (int)x != (int)KarateMan.NoriMode.None, new string[] { "startColor" })
                         }),
                         new Param("hitsPerHeart", new EntityTypes.Float(0f, 20f, 0f), "Hits Per Heart", "How many hits will it take for each heart to light up? (0 will do it automatically.)"),
                         new Param("toggle", true, "Enable Combos", "Allow the player to combo? (Contextual combos will still be allowed even when off)"),
@@ -271,7 +271,7 @@ namespace HeavenStudio.Games.Loaders
                     function = delegate {
                         var e = eventCaller.currentEntity;
                         KarateMan.instance.BackgroundColor(
-                            e.beat, e.length, 
+                            e.beat, e.length,
                             e["presetBg"], e["startColor"], e["endColor"], e["ease"],
                             e["shadowType"], e["shadowStart"], e["shadowEnd"],
                             e["textureType"], e["autoColor"], e["startTexture"], e["endTexture"]
@@ -285,34 +285,41 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("presetBg", KarateMan.BackgroundType.Yellow, "Preset BG Color", "The preset background type (will by default fade from the existing background color)", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)KarateMan.BackgroundType.Custom, new string[] { "startColor", "endColor" })
+                            new Param.CollapseParam((x, y) => {
+                                Debug.Log(y["endColor"]);
+                                RiqEntity bg = GameManager.instance.Beatmap.Entities.FindLast(c => c.beat <= y.beat && c.datamodel == "karateman/background appearance");
+                                y["startColor"] = bg["endColor"];
+                                y["endColor"] = KarateMan.BackgroundColors[(int)x];
+                                Debug.Log(y["endColor"]);
+                                return true;
+                            }, new string[] { /* "startColor", "endColor" */ "presetBg" })
                         }),
                         new Param("startColor", new Color(0.985f, 0.79f, 0.243f), "Start BG Color", "The background color to start with"),
                         new Param("endColor", new Color(0.985f, 0.79f, 0.243f), "End BG Color", "The background color to end with"),
                         new Param("ease", Util.EasingFunction.Ease.Instant, "BG Color Ease", "Ease to use when fading color", new List<Param.CollapseParam>()
                         {
-                            //new Param.CollapseParam(x => (int)x != (int)Util.EasingFunction.Ease.Instant, new string[] { "startColor" })
+                            new Param.CollapseParam((x, _) => (int)x != (int)Util.EasingFunction.Ease.Instant, new string[] { "startColor" })
                         }),
                         new Param("shadowType", KarateMan.ShadowType.Tinted, "Shadow Type", "The shadow type. If Tinted doesn't work with your background color try Custom", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)KarateMan.ShadowType.Custom, new string[] { "shadowStart", "shadowEnd" }),
+                            new Param.CollapseParam((x, _) => (int)x == (int)KarateMan.ShadowType.Custom, new string[] { "shadowStart", "shadowEnd" }),
                         }),
                         new Param("shadowStart", new Color(), "Start Shadow Color", "The shadow color to start with"),
                         new Param("shadowEnd", new Color(), "End Shadow Color", "The shadow color to end with"),
                         
                         new Param("textureType", KarateMan.BackgroundTextureType.Plain, "Texture", "The type of background texture to use", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x != (int)KarateMan.BackgroundTextureType.Plain, new string[] { "startTexture", "endTexture" })
+                            new Param.CollapseParam((x, _) => (int)x != (int)KarateMan.BackgroundTextureType.Plain, new string[] { "startTexture", "endTexture" })
                         }),
                         new Param("autoColor", true, "Use BG Color For Texture", "Use a tint of the background color for the texture?", new List<Param.CollapseParam>()
                         {
-                            //new Param.CollapseParam(x => (int)x != (int)KarateMan.ShadowType.Tinted, new string[] { "startTexture", "endTexture" })
+                            new Param.CollapseParam((x, _) => !(bool)x, new string[] { "startTexture", "endTexture" })
                         }),
                         new Param("startTexture", new Color(), "Start Texture Color", "The texture color to start with"),
                         new Param("endTexture", new Color(), "End Texture Color", "The texture color to end with"),
                         new Param("fxType", new EntityTypes.Integer(0, 3, 3), "Check Tooltip", "Ping @AstrlJelly on discord if you see this; it should be hidden.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => false, new string[] { "fxType" })
+                            new Param.CollapseParam((x, _) => false, new string[] { "fxType" })
                         }),
                     },
                 },
@@ -532,7 +539,7 @@ namespace HeavenStudio.Games
         public float NoriPerformance { get { if (IsNoriActive) return Nori.Nori / Nori.MaxNori; else return 1f; } }
 
         public Color[] LightBulbColors;
-        public Color[] BackgroundColors;
+        public static Color[] BackgroundColors;
 
         //camera positions (normal, special)
         [Header("Camera Positions")]
@@ -783,7 +790,7 @@ namespace HeavenStudio.Games
             Word.Play(DoWordSound(beat, length, type, pitchVoice, forcePitch, customLength, doSound));
         }
 
-        public static string DoWordSound(double beat, double length, int type, bool pitchVoice = false, float forcePitch = 1, bool customLength = false, bool doSound = true)
+        public static string DoWordSound(double beat, double length, int type, bool bpmPitch = false, float forcePitch = 1, bool customLength = false, bool doSound = true)
         {
             double clear = type switch {
                 <= (int)HitThree.HitFour => beat + 4f,
@@ -799,9 +806,7 @@ namespace HeavenStudio.Games
                     new MultiSound.Sound($"karateman/{(type == (int)HitThree.HitThreeAlt ? "hitAlt" : "hit")}", beat + 0.5f, offset: 0.042f),
                     new MultiSound.Sound($"karateman/{number}", beat + 1f),
                 };
-                if (pitchVoice) {
-                    Array.ForEach(sounds, x => x.pitch = (forcePitch == 1) ? Conductor.instance.GetBpmAtBeat(x.beat) / 125 : forcePitch);
-                }
+                Array.ForEach(sounds, x => x.pitch = bpmPitch ? Conductor.instance.GetBpmAtBeat(x.beat) / 125 : forcePitch);
                 MultiSound.Play(sounds, forcePlay: true);
             }
 
@@ -891,7 +896,7 @@ namespace HeavenStudio.Games
             SoundByte.PlayOneShotGame("karateman/barrelOutCombos", forcePlay: true);
         }
 
-        public void Combo(double beat, int expression, bool pitchVoice, float forcePitch, bool cutOut, bool noVoice)
+        public void Combo(double beat, int expression, bool bpmPitch, float forcePitch, bool cutOut, bool noVoice)
         {
             int comboId = KarateManPot.GetNewCombo();
 
@@ -916,10 +921,6 @@ namespace HeavenStudio.Games
                 new MultiSound.Sound("karateman/pow", beat + 2.5f)
             };
 
-            if (pitchVoice) {
-                sounds.ForEach(x => x.pitch = (forcePitch == 1) ? Conductor.instance.GetBpmAtBeat(x.beat) / 125 : forcePitch);
-            }
-
             if (voiceEntities.Count > 0 && cutOut)
             {
                 RiqEntity firstVoice = voiceEntities.Find(x => x.beat >= beat + 1);
@@ -927,6 +928,8 @@ namespace HeavenStudio.Games
                 if (firstVoice != null) sounds.RemoveAll(x => x.beat > firstVoice.beat);
                 if (firstHitVoice != null) sounds.RemoveAll(x => x.beat > firstHitVoice.beat - 0.5);
             }
+
+            sounds.ForEach(x => x.pitch = bpmPitch ? Conductor.instance.GetBpmAtBeat(x.beat) / 125 : forcePitch);
             
             MultiSound.Play(sounds.ToArray(), forcePlay: true);
         }
@@ -936,7 +939,7 @@ namespace HeavenStudio.Games
             SoundByte.PlayOneShotGame("karateman/barrelOutKicks", forcePlay: true);
         }
 
-        public void Kick(double beat, bool ball, bool glow, int expression, bool pitchVoice, float forcePitch, bool cutOut, bool noVoice, Color woodColor, Color hoopColor)
+        public void Kick(double beat, bool ball, bool glow, int expression, bool bpmPitch, float forcePitch, bool cutOut, bool noVoice, Color woodColor, Color hoopColor)
         {
             var barrel = CreateItemInstance(beat, "Item05", expression, KarateManPot.ItemType.KickBarrel, content: ball, shouldGlow: glow);
             // red : new Color(0.451f, 0.302f, 0.271f)
@@ -954,10 +957,6 @@ namespace HeavenStudio.Games
                 new MultiSound.Sound("karateman/punchKick4", beat + 2.5f),
             };
 
-            if (pitchVoice) {
-                sounds.ForEach(x => x.pitch = (forcePitch == 1) ? Conductor.instance.GetBpmAtBeat(x.beat) / 125 : forcePitch);
-            }
-
             if (voiceEntities.Count > 0 && cutOut)
             {
                 RiqEntity firstVoice = voiceEntities.Find(x => x.beat >= beat + 1);
@@ -965,6 +964,8 @@ namespace HeavenStudio.Games
                 if (firstVoice != null) sounds.RemoveAll(x => x.beat > firstVoice.beat);
                 if (firstHitVoice != null) sounds.RemoveAll(x => x.beat > firstHitVoice.beat);
             }
+
+            sounds.ForEach(x => x.pitch = bpmPitch ? Conductor.instance.GetBpmAtBeat(x.beat) / 125 : forcePitch);
             
             MultiSound.Play(sounds.ToArray(), forcePlay: true);
         }
@@ -995,16 +996,15 @@ namespace HeavenStudio.Games
                 colorEases[i] = (Util.EasingFunction.Ease)colorEaseSet;
             }
 
-            bool preset = presetBG != (int)BackgroundType.Custom;
             bool tinted = shadowType == (int)ShadowType.Tinted;
-            Color bgColorStart = preset ? BGPlane.color : colorStart;
+            Color bgColorStart = colorStart;
             colorStarts = new Color[] {
                 bgColorStart,
                 tinted ? TintColor(bgColorStart) : shadowStart,
                 autoColor ? TintColor(bgColorStart): filterStart,
             };
 
-            Color bgColorEnd = preset ? BackgroundColors[presetBG] : colorEnd;
+            Color bgColorEnd = colorEnd;
             colorEnds = new Color[] {
                 bgColorEnd,
                 tinted ? TintColor(bgColorEnd) : shadowEnd,

--- a/Assets/Scripts/Games/LaunchParty/LaunchParty.cs
+++ b/Assets/Scripts/Games/LaunchParty/LaunchParty.cs
@@ -123,7 +123,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("toggle", true, "Stars Enabled", "Starfall Or No?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "valA", "valB", "valC"})
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "valA", "valB", "valC"})
                         }),
                         new Param("valA", new EntityTypes.Float(0.1f, 10f, 1f), "Star Density", "How many stars are on the screen"),
                         new Param("valB", new EntityTypes.Float(0.01f, 5f, 0.1f), "Front Star Fall Speed", "How fast the front stars fall to the edge of the screen"),

--- a/Assets/Scripts/Games/Lockstep/Lockstep.cs
+++ b/Assets/Scripts/Games/Lockstep/Lockstep.cs
@@ -36,7 +36,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("sound", false, "Sound", "Hai if onbeat, ho if offbeat.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "amount" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "amount" })
                         }),
                         new Param("amount", new EntityTypes.Integer(1, 50, 1), "Sound Amount", "How many sounds will play consecutively?"),
                         new Param("visual", true, "Background Visual")
@@ -106,7 +106,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("sound", false, "Sound", "Hai if onbeat, ho if offbeat.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "amount" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "amount" })
                         }),
                         new Param("amount", new EntityTypes.Integer(1, 50, 1), "Sound Amount", "How many sounds will play consecutively?"),
                         new Param("visual", true, "Background Visual")

--- a/Assets/Scripts/Games/OctopusMachine/Octopus.cs
+++ b/Assets/Scripts/Games/OctopusMachine/Octopus.cs
@@ -15,7 +15,7 @@ namespace HeavenStudio.Games.Scripts_OctopusMachine
         public bool cantBop;
         public bool isSqueezed;
         public bool isPreparing;
-        public bool queuePrepare;
+        public double queuePrepare;
         public double lastReportedBeat = 0f;
         double lastSqueezeBeat;
         bool isActive = true;
@@ -25,16 +25,17 @@ namespace HeavenStudio.Games.Scripts_OctopusMachine
         void Awake()
         {
             game = OctopusMachine.instance;
+            queuePrepare = double.MaxValue;
         }
 
         void Update()
         {
-            if (queuePrepare && Conductor.instance.NotStopped()) {
+            if (queuePrepare <= Conductor.instance.songPositionInBeatsAsDouble && Conductor.instance.NotStopped()) {
                 if (!(isPreparing || isSqueezed || anim.IsPlayingAnimationName("Release") || anim.IsPlayingAnimationName("Pop"))) 
                 {
-                    anim.DoScaledAnimationAsync("Prepare", 0.5f);
+                    anim.DoScaledAnimationFromBeatAsync("Prepare", 0.5f, queuePrepare);
                     isPreparing = true;
-                    queuePrepare = false;
+                    queuePrepare = double.MaxValue;
                 }
             }
             
@@ -98,15 +99,15 @@ namespace HeavenStudio.Games.Scripts_OctopusMachine
             isActive = enable;
         }
 
-        public void OctoAction(string action) 
+        public void OctoAction(string action)
         {
             if (action != "Release" || (Conductor.instance.songPositionInBeatsAsDouble - lastSqueezeBeat) > 0.15f) SoundByte.PlayOneShotGame($"octopusMachine/{action.ToLower()}");
             if (action == "Squeeze") lastSqueezeBeat = Conductor.instance.songPositionInBeatsAsDouble;
 
             anim.DoScaledAnimationAsync(action, 0.5f);
-            isSqueezed = (action == "Squeeze");
-            isPreparing =
-            queuePrepare = false;
+            isSqueezed = action == "Squeeze";
+            isPreparing = false;
+            queuePrepare = double.MaxValue;
         }
 
         public void AnimationColor(int poppingColor) 

--- a/Assets/Scripts/Games/OctopusMachine/OctopusMachine.cs
+++ b/Assets/Scripts/Games/OctopusMachine/OctopusMachine.cs
@@ -44,7 +44,7 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>() {
                         new Param("shouldPrep", true, "Prepare?", "Plays a prepare animation before the cue.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "prepBeats" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "prepBeats" })
                         }),
                         new Param("prepBeats", new EntityTypes.Float(0, 4, 1), "Prepare Beats", "How many beats before the cue does the octopus prepare?"),
                     },
@@ -84,7 +84,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("autoBop", true, "Hit/Miss Bop", "Plays a bop depending on if you hit or missed the cues."),
                         new Param("autoText", true, "Display Text", "Displays text depending on if you hit or missed the cues.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "hitText", "missText" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "hitText", "missText" })
                         }),
                         new Param("hitText", "Good!", "Hit Text", "The text to display if you hit the cues."),
                         new Param("missText", "Wrong! Try again!", "Miss Text", "The text to display if you missed the cues."),
@@ -109,7 +109,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("isInstant", true, "Instant", "Will the bubbles disappear appear?"),
                         new Param("setActive", OctopusMachine.Actives.Activate, "Activate or Deactivate", "Will the bubbles disappear or appear?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)OctopusMachine.Actives.Activate, new string[] { "particleStrength" })
+                            new Param.CollapseParam((x, _) => (int)x == (int)OctopusMachine.Actives.Activate, new string[] { "particleStrength" })
                         }),
                         new Param("particleStrength", new EntityTypes.Float(0, 25, 3), "Bubble Intensity", "The amount of bubbles"),
                         new Param("particleSpeed", new EntityTypes.Float(0, 25, 5), "Bubble Speed", "The speed of the bubbles"),
@@ -150,19 +150,19 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>() {
                         new Param("oct1", true, "Show Octopus 1", "Should the first octopus be enabled?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "oct1x", "oct1y" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "oct1x", "oct1y" })
                         }),
                         new Param("oct1x", new EntityTypes.Float(-10, 10, -4.64f), "X Octopus 1", "Change Octopus 1's X"),
                         new Param("oct1y", new EntityTypes.Float(-10, 10, 2.5f), "Y Octopus 1", "Change Octopus 1's Y"),
                         new Param("oct2", true, "Show Octopus 2", "Should the second octopus be enabled?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "oct2x", "oct2y" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "oct2x", "oct2y" })
                         }),
                         new Param("oct2x", new EntityTypes.Float(-10, 10, -0.637f), "X Octopus 2", "Change Octopus 2's X"),
                         new Param("oct2y", new EntityTypes.Float(-10, 10, 0f), "Y Octopus 2", "Change Octopus 2's Y"),
                         new Param("oct3", true, "Show Octopus 3", "Should the third octopus be enabled?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "oct3x", "oct3y" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "oct3x", "oct3y" })
                         }),
                         new Param("oct3x", new EntityTypes.Float(-10, 10, 3.363f), "X Octopus 3", "Change Octopus 3's X"),
                         new Param("oct3y", new EntityTypes.Float(-10, 10, -2.5f), "Y Octopus 3", "Change Octopus 3's Y"),
@@ -312,7 +312,7 @@ namespace HeavenStudio.Games
 
                 var main = bubble.main;
                 main.prewarm = isInstant;
-                main.simulationSpeed = particleSpeed/10;
+                main.simulationSpeed = particleSpeed / 10;
 
                 var emm = bubble.emission;
                 emm.rateOverTime = particleStrength;
@@ -379,12 +379,9 @@ namespace HeavenStudio.Games
         //call this in OnPlay(double beat) and OnGameSwitch(double beat)
         private void PersistColor(double beat)
         {
-            var allEventsBeforeBeat = EventCaller.GetAllInGameManagerList("octopusMachine", new string[] { "changeColor" }).FindAll(x => x.beat < beat);
-            if (allEventsBeforeBeat.Count > 0)
-            {
-                allEventsBeforeBeat.Sort((x, y) => x.beat.CompareTo(y.beat)); //just in case
-                var lastEvent = allEventsBeforeBeat[^1];
-                BackgroundColor(lastEvent.beat, lastEvent.length, lastEvent["color1"], lastEvent["color2"], lastEvent["octoColor"], lastEvent["squeezedColor"], lastEvent["ease"]);
+            var bgColor = GameManager.instance.Beatmap.Entities.FindLast(c => c.datamodel == "octopusMachine/changeColor" && c.beat < beat);
+            if (bgColor != null) {
+                BackgroundColor(bgColor.beat, bgColor.length, bgColor["color1"], bgColor["color2"], bgColor["octoColor"], bgColor["squeezedColor"], bgColor["ease"]);
             }
         }
 

--- a/Assets/Scripts/Games/QuizShow/QuizShow.cs
+++ b/Assets/Scripts/Games/QuizShow/QuizShow.cs
@@ -23,7 +23,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("auto", true, "Auto Pass Turn", "", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "sound", "con", "visual", "audio" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "sound", "con", "visual", "audio" })
                         }),
                         new Param("sound", true, "Play Time-Up Sound?", "Should the Time-Up sound play at the end of the interval?"),
                         new Param("con", false, "Consecutive", "Disables everything that happens at the end of the interval if ticked on."),

--- a/Assets/Scripts/Games/SeeSaw/SeeSaw.cs
+++ b/Assets/Scripts/Games/SeeSaw/SeeSaw.cs
@@ -21,7 +21,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "height", "camMove" })
                         }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
@@ -35,7 +35,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "height", "camMove" })
                         }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
@@ -49,7 +49,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "height", "camMove" })
                         }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")
@@ -63,7 +63,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("high", false, "High", "Will they perform high jumps?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "height", "camMove" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "height", "camMove" })
                         }),
                         new Param("height", new EntityTypes.Float(0, 1, 0), "Height", "Controls how high the high jump will go, 0 is the minimum height, 1 is the maximum height."),
                         new Param("camMove", true, "Camera Movement", "Will the camera follow saw when it jumps up high?")

--- a/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
+++ b/Assets/Scripts/Games/SpaceSoccer/SpaceSoccer.cs
@@ -41,7 +41,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("preset", SpaceSoccer.EnterExitPresets.FiveKickers, "Preset", "Which preset should be used?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)SpaceSoccer.EnterExitPresets.Custom, new string[] { "amount", "x", "y", "z" })
+                            new Param.CollapseParam((x, _) => (int)x == (int)SpaceSoccer.EnterExitPresets.Custom, new string[] { "amount", "x", "y", "z" })
                         }),
                         
                         
@@ -78,7 +78,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("preset", SpaceSoccer.PlayerPresets.LaunchStart, "Preset", "Which preset should be used?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)SpaceSoccer.PlayerPresets.Custom, new string[] { "x", "y", "z", "ease", "sound" })
+                            new Param.CollapseParam((x, _) => (int)x == (int)SpaceSoccer.PlayerPresets.Custom, new string[] { "x", "y", "z", "ease", "sound" })
                         }),
                         new Param("x", new EntityTypes.Float(-30, 30, 0f), "X Pos", "Which position should the player move to on the x axis?"),
                         new Param("y", new EntityTypes.Float(-30, 30, 0f), "Y Pos", "Which position should the player move to on the y axis?"),

--- a/Assets/Scripts/Games/TapTrial/TapTrial.cs
+++ b/Assets/Scripts/Games/TapTrial/TapTrial.cs
@@ -58,7 +58,7 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("toggle", true, "Scroll FX", "Will scroll", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "flash", "m"})
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "flash", "m"})
                         }),
                         new Param("flash", true, "Flash FX", "Will flash to white"),
                         new Param("m", new EntityTypes.Float(0, 10, 1), "Speed Multiplier")

--- a/Assets/Scripts/Games/TapTroupe/TapTroupe.cs
+++ b/Assets/Scripts/Games/TapTroupe/TapTroupe.cs
@@ -33,12 +33,12 @@ namespace HeavenStudio.Games.Loaders
                     {
                         new Param("okay", true, "Okay Voice Line", "Whether or not the tappers should say -Okay!- after successfully tapping.", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (bool)x, new string[] { "okayType" })
+                            new Param.CollapseParam((x, _) => (bool)x, new string[] { "okayType" })
                         }),
                         new Param("okayType", TapTroupe.OkayType.OkayA, "Okay Type", "Which version of the okay voice line should the tappers say?"),
                         new Param("animType", TapTroupe.OkayAnimType.Normal, "Okay Animation", "Which animations should be played when the tapper say OK?", new List<Param.CollapseParam>()
                         {
-                            new Param.CollapseParam(x => (int)x == (int)TapTroupe.OkayAnimType.Popper, new string[]{ "popperBeats"})
+                            new Param.CollapseParam((x, _) => (int)x == (int)TapTroupe.OkayAnimType.Popper, new string[]{ "popperBeats"})
                         }),
                         new Param("popperBeats", new EntityTypes.Float(0f, 80f, 2f), "Popper Beats", "How many beats until the popper will pop?"),
                         new Param("randomVoiceLine", true, "Extra Random Voice Line", "Whether there should be randomly said woos or laughs after the tappers say OK!"),

--- a/Assets/Scripts/LevelEditor/EventSelector/EventParameterManager.cs
+++ b/Assets/Scripts/LevelEditor/EventSelector/EventParameterManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using HeavenStudio.Editor.Track;
 using Jukebox;
 using Jukebox.Legacy;
+using System.Linq;
 
 namespace HeavenStudio.Editor
 {
@@ -111,12 +112,8 @@ namespace HeavenStudio.Editor
                     EventPropertyPrefab input = ePrefabs[p.propertyName].GetComponent<EventPropertyPrefab>();
                     foreach (var c in p.collapseParams)
                     {
-                        List<GameObject> collapseables = new();
-                        foreach (var s in c.collapseables)
-                        {
-                            collapseables.Add(ePrefabs[s]);
-                        }
-                        input.propertyCollapses.Add(new EventPropertyPrefab.PropertyCollapse(collapseables, c.CollapseOn));
+                        List<GameObject> collapseables = c.collapseables.Select(x => ePrefabs[x]).ToList();
+                        input.propertyCollapses.Add(new EventPropertyPrefab.PropertyCollapse(collapseables, c.CollapseOn, entity));
                     }
                     input.SetCollapses(p.parameter);
                 }

--- a/Assets/Scripts/LevelEditor/EventSelector/EventPropertyPrefab.cs
+++ b/Assets/Scripts/LevelEditor/EventSelector/EventPropertyPrefab.cs
@@ -8,6 +8,7 @@ using TMPro;
 using Starpelly;
 
 using HeavenStudio.Util;
+using Jukebox;
 
 namespace HeavenStudio.Editor
 {
@@ -38,7 +39,7 @@ namespace HeavenStudio.Editor
             {
                 foreach (var c in p.collapseables)
                 {
-                    if (c != null) c.SetActive(p.collapseOn(type) && gameObject.activeSelf);
+                    if (c != null) c.SetActive(p.collapseOn(type, p.entity) && gameObject.activeSelf);
                 }
             }
         }
@@ -46,12 +47,14 @@ namespace HeavenStudio.Editor
         public class PropertyCollapse
         {
             public List<GameObject> collapseables;
-            public Func<object, bool> collapseOn;
+            public Func<object, RiqEntity, bool> collapseOn;
+            public RiqEntity entity;
 
-            public PropertyCollapse(List<GameObject> collapseables, Func<object, bool> collapseOn)
+            public PropertyCollapse(List<GameObject> collapseables, Func<object, RiqEntity, bool> collapseOn, RiqEntity entity)
             {
                 this.collapseables = collapseables;
                 this.collapseOn = collapseOn;
+                this.entity = entity;
             }
         }
     }

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -486,14 +486,14 @@ namespace HeavenStudio
 
             public class CollapseParam
             {
-                public Func<object, bool> CollapseOn;
+                public Func<object, RiqEntity, bool> CollapseOn;
                 public string[] collapseables;
                 /// <summary>
                 /// Class that decides how other parameters will be collapsed
                 /// </summary>
                 /// <param name="collapseOn">What values should make it collapse/uncollapse?</param>
                 /// <param name="collapseables">IDs of the parameters to collapse</param>
-                public CollapseParam(Func<object, bool> collapseOn, string[] collapseables)
+                public CollapseParam(Func<object, RiqEntity, bool> collapseOn, string[] collapseables)
                 {
                     CollapseOn = collapseOn;
                     this.collapseables = collapseables;

--- a/Assets/Scripts/Util/AnimationHelpers.cs
+++ b/Assets/Scripts/Util/AnimationHelpers.cs
@@ -66,8 +66,8 @@ namespace HeavenStudio.Util
             if (!double.IsNaN(startBeat)) {
                 var cond = Conductor.instance;
                 var animClip = Array.Find(anim.runtimeAnimatorController.animationClips, x => x.name == animName);
-                double animLength = cond.GetBeatFromSongPos(cond.GetSongPosFromBeat(startBeat) + animClip.length);
-                pos = cond.GetPositionFromBeat(startBeat, animLength - startBeat) * timeScale;
+                double animLength = cond.SecsToBeats(animClip.length, cond.GetBpmAtBeat(startBeat));
+                pos = cond.GetPositionFromBeat(startBeat, animLength) * timeScale;
             } else {
                 Debug.LogWarning("DoScaledAnimationFromBeatAsync()'s startBeat was NaN; using DoScaledAnimationAsync() instead.");
             }

--- a/Assets/Scripts/Util/AnimationHelpers.cs
+++ b/Assets/Scripts/Util/AnimationHelpers.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System;
 
 namespace HeavenStudio.Util
 {
@@ -14,7 +15,7 @@ namespace HeavenStudio.Util
         /// </summary>
         /// <param name="anim">Animator to check</param>
         /// <param name="animName">name of animation to look out for</param>
-        public static bool IsPlayingAnimationName(this Animator anim, string animName) 
+        public static bool IsPlayingAnimationName(this Animator anim, string animName)
         {
             var stateInfo = anim.GetCurrentAnimatorStateInfo(0);
             return (stateInfo.normalizedTime < stateInfo.speed || stateInfo.loop) && stateInfo.IsName(animName);
@@ -52,7 +53,27 @@ namespace HeavenStudio.Util
 
         /// <summary>
         /// Plays animation on animator, scaling speed to song BPM
-        /// call this funtion once, when playing an animation
+        /// call this function once, when playing an animation
+        /// </summary>
+        /// <param name="anim">Animator to play animation on</param>
+        /// <param name="animName">name of animation to play</param>
+        /// <param name="timeScale">multiplier for animation speed</param>
+        /// <param name="startBeat">beat that this animation would start on</param>
+        /// <param name="currentBeat">how many beats after startBeat that the animation actually starts playing</param>
+        /// <param name="animLayer">animator layer to play animation on</param>
+        public static void DoScaledAnimationFromBeatAsync(this Animator anim, string animName, float timeScale = 1f, double startBeat = 0, double currentBeat = 0, int animLayer = -1)
+        {
+            var cond = Conductor.instance;
+            var animClip = Array.Find(anim.runtimeAnimatorController.animationClips, x => x.name == animName);
+            var animLength = cond.GetBeatFromSongPos(cond.GetSongPosFromBeat(startBeat) + animClip.length);
+            var pos = cond.GetPositionFromBeat(startBeat + currentBeat, animLength) * timeScale;
+            anim.Play(animName, animLayer, pos);
+            anim.speed = 1f / (cond.pitchedSecPerBeat * timeScale);
+        }
+
+        /// <summary>
+        /// Plays animation on animator, scaling speed to song BPM
+        /// call this function once, when playing an animation
         /// </summary>
         /// <param name="anim">Animator to play animation on</param>
         /// <param name="animName">name of animation to play</param>

--- a/Assets/Scripts/Util/AnimationHelpers.cs
+++ b/Assets/Scripts/Util/AnimationHelpers.cs
@@ -52,23 +52,26 @@ namespace HeavenStudio.Util
         }
 
         /// <summary>
-        /// Plays animation on animator, scaling speed to song BPM
+        /// Plays animation on animator, scaling speed to song BPM 
         /// call this function once, when playing an animation
         /// </summary>
         /// <param name="anim">Animator to play animation on</param>
         /// <param name="animName">name of animation to play</param>
         /// <param name="timeScale">multiplier for animation speed</param>
         /// <param name="startBeat">beat that this animation would start on</param>
-        /// <param name="currentBeat">how many beats after startBeat that the animation actually starts playing</param>
         /// <param name="animLayer">animator layer to play animation on</param>
-        public static void DoScaledAnimationFromBeatAsync(this Animator anim, string animName, float timeScale = 1f, double startBeat = 0, double currentBeat = 0, int animLayer = -1)
+        public static void DoScaledAnimationFromBeatAsync(this Animator anim, string animName, float timeScale = 1f, double startBeat = 0, int animLayer = -1)
         {
-            var cond = Conductor.instance;
-            var animClip = Array.Find(anim.runtimeAnimatorController.animationClips, x => x.name == animName);
-            var animLength = cond.GetBeatFromSongPos(cond.GetSongPosFromBeat(startBeat) + animClip.length);
-            var pos = cond.GetPositionFromBeat(startBeat + currentBeat, animLength) * timeScale;
-            anim.Play(animName, animLayer, pos);
-            anim.speed = 1f / (cond.pitchedSecPerBeat * timeScale);
+            float pos = 0;
+            if (!double.IsNaN(startBeat)) {
+                var cond = Conductor.instance;
+                var animClip = Array.Find(anim.runtimeAnimatorController.animationClips, x => x.name == animName);
+                double animLength = cond.GetBeatFromSongPos(cond.GetSongPosFromBeat(startBeat) + animClip.length);
+                pos = cond.GetPositionFromBeat(startBeat, animLength - startBeat) * timeScale;
+            } else {
+                Debug.LogWarning("DoScaledAnimationFromBeatAsync()'s startBeat was NaN; using DoScaledAnimationAsync() instead.");
+            }
+            anim.DoScaledAnimationAsync(animName, timeScale, pos, animLayer);
         }
 
         /// <summary>


### PR DESCRIPTION
* you can now cue fork lifter while inactive
* the dreaded fork lifter woosh sfx is fixed
* octopus machine prepare should look better
 -i didn't do too much testing with it so feel free to dm me riqs that aren't working with it (if there are any)

internal stuff : 
* DoScaledAnimationFromBeatAsync() is a method that plays an animation as if it was playing on a certain beat
 -this is mostly useful for cues or prepares
* you can now access the riqentity through the func of a collapsing property
 -i think im gonna keep tinkering with the collapse properties though cuz they could probably be better/more useful