### PR TITLE
3D Camera and Viewport Position Update Fixes

### DIFF
--- a/Assets/Scripts/GameCamera.cs
+++ b/Assets/Scripts/GameCamera.cs
@@ -38,15 +38,42 @@ namespace HeavenStudio
         /**
             camera's current transformation
         **/
-        private static Vector3 position;
-        private static Vector3 rotEluer;
-        private static Vector3 shakeResult;
+        private static Vector3 _position;
+        private static Vector3 Position
+        {
+            get => _position;
+            set
+            {
+                _position = value;
+                instance.ApplyCameraValues();
+            }
+        }
+        private static Vector3 _rotEuler;
+        private static Vector3 RotEuler
+        {
+            get => _rotEuler;
+            set
+            {
+                _rotEuler = value;
+                instance.ApplyCameraValues();
+            }
+        }
+        private static Vector3 _shakeResult;
+        private static Vector3 ShakeResult
+        {
+            get => _shakeResult;
+            set
+            {
+                _shakeResult = value;
+                instance.ApplyCameraValues();
+            }
+        }
 
         /**
             camera's last transformation
         **/
         private static Vector3 positionLast;
-        private static Vector3 rotEluerLast;
+        private static Vector3 rotEulerLast;
         private static Vector3 shakeLast;
 
         /** 
@@ -54,10 +81,46 @@ namespace HeavenStudio
             to use in minigame scripts (Spaceball, Rhythm Rally, Built to Scale, etc.)
             and NOT in the editor
         **/
-        public static Vector3 additionalPosition;
-        public static Vector3 additionalRotEluer;
-        public static Vector3 additionalScale;
-        public static float additionalFoV;
+        private static Vector3 _additionalPosition;
+        public static Vector3 AdditionalPosition
+        {
+            get => _additionalPosition;
+            set
+            {
+                _additionalPosition = value;
+                instance.ApplyCameraValues();
+            }
+        }
+        private static Vector3 _additionalRotEuler;
+        public static Vector3 AdditionalRotEuler
+        {
+            get => _additionalRotEuler;
+            set
+            {
+                _additionalRotEuler = value;
+                instance.ApplyCameraValues();
+            }
+        }
+        private static Vector3 _additionalScale;
+        public static Vector3 AdditionalScale
+        {
+            get => _additionalScale;
+            set
+            {
+                _additionalScale = value;
+                instance.ApplyCameraValues();
+            }
+        }
+        private static float _additionalFoV;
+        public static float AdditionalFoV
+        {
+            get => _additionalFoV;
+            set
+            {
+                _additionalFoV = value;
+                instance.ApplyCameraValues();
+            }
+        }
 
         [Header("Components")]
         public Color baseColor;
@@ -80,7 +143,7 @@ namespace HeavenStudio
             currentColor = baseColor;
             
             positionLast = defaultPosition;
-            rotEluerLast = defaultRotEluer;
+            rotEulerLast = defaultRotEluer;
         }
 
         public void OnBeatChanged(double beat)
@@ -90,7 +153,7 @@ namespace HeavenStudio
             currentColor = baseColor;
 
             positionLast = defaultPosition;
-            rotEluerLast = defaultRotEluer;
+            rotEulerLast = defaultRotEluer;
 
             // this entire thing is a mess redo it later
             //pos
@@ -127,13 +190,19 @@ namespace HeavenStudio
         private void LateUpdate()
         {
             Camera cam = GetCamera();
-            // rotate position by additional rotation
-            Vector3 userPos = Quaternion.Euler(additionalRotEluer) * position;
-            cam.transform.localPosition = userPos + additionalPosition + shakeResult;
-            cam.transform.eulerAngles = rotEluer + additionalRotEluer;
-            cam.fieldOfView = additionalFoV;
             cam.backgroundColor = currentColor;
             if (!StaticCamera.instance.usingMinigameAmbientColor) StaticCamera.instance.SetAmbientGlowColour(currentColor, false, false);
+        }
+
+        private void ApplyCameraValues()
+        {
+            Camera cam = GetCamera();
+            // rotate position by additional rotation
+            Vector3 userPos = Quaternion.Euler(_additionalRotEuler) * _position;
+            cam.transform.localPosition = userPos + _additionalPosition + _shakeResult;
+            cam.transform.eulerAngles = _rotEuler + _additionalRotEuler;
+            cam.fieldOfView = _additionalFoV;
+            Debug.Log("Camera Pos: " + _additionalPosition);
         }
 
         private void UpdateCameraColor()
@@ -168,19 +237,19 @@ namespace HeavenStudio
                     switch (e["axis"])
                     {
                         case (int) CameraAxis.X:
-                            position.x = func(positionLast.x, e["valA"], Mathf.Min(prog, 1f));
+                            Position = new Vector3(func(positionLast.x, e["valA"], Mathf.Min(prog, 1f)), Position.y, Position.z);
                             break;
                         case (int) CameraAxis.Y:
-                            position.y = func(positionLast.y, e["valB"], Mathf.Min(prog, 1f));
+                            Position = new Vector3(Position.x, func(positionLast.y, e["valB"], Mathf.Min(prog, 1f)), Position.z);
                             break;
                         case (int) CameraAxis.Z:
-                            position.z = func(positionLast.z, -e["valC"], Mathf.Min(prog, 1f));
+                            Position = new Vector3(Position.x, Position.y, func(positionLast.z, -e["valC"], Mathf.Min(prog, 1f)));
                             break;
                         default:
                             float dx = func(positionLast.x, e["valA"], Mathf.Min(prog, 1f));
                             float dy = func(positionLast.y, e["valB"], Mathf.Min(prog, 1f));
                             float dz = func(positionLast.z, -e["valC"], Mathf.Min(prog, 1f));
-                            position = new Vector3(dx, dy, dz);
+                            Position = new Vector3(dx, dy, dz);
                             break;
                     }
                 }
@@ -216,19 +285,19 @@ namespace HeavenStudio
                     switch (e["axis"])
                     {
                         case (int) CameraAxis.X:
-                            rotEluer.x = func(rotEluerLast.x, e["valA"], Mathf.Min(prog, 1f));
+                            RotEuler = new Vector3(func(rotEulerLast.x, e["valA"], Mathf.Min(prog, 1f)), RotEuler.y, RotEuler.z);
                             break;
                         case (int) CameraAxis.Y:
-                            rotEluer.y = func(rotEluerLast.y, e["valB"], Mathf.Min(prog, 1f));
+                            RotEuler = new Vector3(RotEuler.x, func(rotEulerLast.y, e["valB"], Mathf.Min(prog, 1f)), RotEuler.z);
                             break;
                         case (int) CameraAxis.Z:
-                            rotEluer.z = func(rotEluerLast.z, -e["valC"], Mathf.Min(prog, 1f));
+                            RotEuler = new Vector3(RotEuler.x, RotEuler.y, func(rotEulerLast.z, -e["valC"], Mathf.Min(prog, 1f)));
                             break;
                         default:
-                            float dx = func(rotEluerLast.x, e["valA"], Mathf.Min(prog, 1f));
-                            float dy = func(rotEluerLast.y, e["valB"], Mathf.Min(prog, 1f));
-                            float dz = func(rotEluerLast.z, -e["valC"], Mathf.Min(prog, 1f));
-                            rotEluer = new Vector3(dx, dy, dz);    //I'm stupid and forgot to negate the rotation gfd 😢
+                            float dx = func(rotEulerLast.x, e["valA"], Mathf.Min(prog, 1f));
+                            float dy = func(rotEulerLast.y, e["valB"], Mathf.Min(prog, 1f));
+                            float dz = func(rotEulerLast.z, -e["valC"], Mathf.Min(prog, 1f));
+                            RotEuler = new Vector3(dx, dy, dz);    //I'm stupid and forgot to negate the rotation gfd 😢
                             break;
                     }
                 }
@@ -237,19 +306,19 @@ namespace HeavenStudio
                     switch (e["axis"])
                     {
                         case (int) CameraAxis.X:
-                            rotEluerLast.x = e["valA"];
+                            rotEulerLast.x = e["valA"];
                             break;
                         case (int) CameraAxis.Y:
-                            rotEluerLast.y = e["valB"];
+                            rotEulerLast.y = e["valB"];
                             break;
                         case (int) CameraAxis.Z:
-                            rotEluerLast.z = -e["valC"];
+                            rotEulerLast.z = -e["valC"];
                             break;
                         default:
-                            rotEluerLast = new Vector3(e["valA"], e["valB"], -e["valC"]);
+                            rotEulerLast = new Vector3(e["valA"], e["valB"], -e["valC"]);
                             break;
                     }
-                    rotEluerLast = new Vector3(e["valA"], e["valB"], -e["valC"]);
+                    rotEulerLast = new Vector3(e["valA"], e["valB"], -e["valC"]);
                 }
             }
         }
@@ -262,27 +331,27 @@ namespace HeavenStudio
                 if (prog >= 0f)
                 {
                     float fac = Mathf.Cos(Time.time * 80f) * 0.5f;
-                    shakeResult = new Vector3(fac * e["valA"], fac * e["valB"]);
+                    ShakeResult = new Vector3(fac * e["valA"], fac * e["valB"]);
                 }
                 if (prog > 1f)
                 {
-                    shakeResult = new Vector3(0, 0);
+                    ShakeResult = new Vector3(0, 0);
                 }
             }
         }
 
         public static void ResetTransforms()
         {
-            position = defaultPosition;
-            rotEluer = defaultRotEluer;
-            shakeResult = defaultShake;
+            Position = defaultPosition;
+            RotEuler = defaultRotEluer;
+            ShakeResult = defaultShake;
         }
 
         public static void ResetAdditionalTransforms()
         {
-            additionalPosition = new Vector3(0, 0, 0);
-            additionalRotEluer = new Vector3(0, 0, 0);
-            additionalFoV = defaultFoV;
+            AdditionalPosition = new Vector3(0, 0, 0);
+            AdditionalRotEuler = new Vector3(0, 0, 0);
+            AdditionalFoV = defaultFoV;
         }
 
         public static Camera GetCamera()

--- a/Assets/Scripts/GameCamera.cs
+++ b/Assets/Scripts/GameCamera.cs
@@ -202,7 +202,7 @@ namespace HeavenStudio
             cam.transform.localPosition = userPos + _additionalPosition + _shakeResult;
             cam.transform.eulerAngles = _rotEuler + _additionalRotEuler;
             cam.fieldOfView = _additionalFoV;
-            Debug.Log("Camera Pos: " + _additionalPosition);
+            //Debug.Log("Camera Pos: " + _additionalPosition);
         }
 
         private void UpdateCameraColor()

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -605,7 +605,7 @@ namespace HeavenStudio
             }
 
             StartCoroutine(PlayCo(beat, delay));
-            onBeatChanged?.Invoke(beat);
+            //onBeatChanged?.Invoke(beat);
         }
 
         private IEnumerator PlayCo(double beat, float delay = 0f)
@@ -649,7 +649,7 @@ namespace HeavenStudio
 
             Conductor.instance.Stop(beat);
             SetCurrentEventToClosest(beat);
-            onBeatChanged?.Invoke(beat);
+            //onBeatChanged?.Invoke(beat);
 
             // I feel like I should standardize the names
             SkillStarManager.instance.KillStar();
@@ -946,6 +946,8 @@ namespace HeavenStudio
 
         private void SetGame(string game, bool useMinigameColor = true)
         {
+            ResetCamera(); // resetting camera before setting new minigame so minigames can set camera values in their awake call - Rasmus
+
             Destroy(currentGameO);
 
             currentGameO = Instantiate(GetGame(game));
@@ -953,8 +955,6 @@ namespace HeavenStudio
             currentGameO.name = game;
 
             SetCurrentGame(game, useMinigameColor);
-
-            ResetCamera();
         }
 
         public void PreloadGameSequences(string game)

--- a/Assets/Scripts/Games/BoardMeeting/BoardMeeting.cs
+++ b/Assets/Scripts/Games/BoardMeeting/BoardMeeting.cs
@@ -431,7 +431,7 @@ namespace HeavenStudio.Games
             if (shakeTween != null)
                 shakeTween.Kill(true);
 
-            DOTween.Punch(() => GameCamera.additionalPosition, x => GameCamera.additionalPosition = x, new Vector3(shakeIntensity, 0, 0),
+            DOTween.Punch(() => GameCamera.AdditionalPosition, x => GameCamera.AdditionalPosition = x, new Vector3(shakeIntensity, 0, 0),
                 Conductor.instance.pitchedSecPerBeat * 0.5f, 18, 1f);
             executives[executiveCount - 1].Stop();
             assistantAnim.DoScaledAnimationAsync("Stop", 0.5f);

--- a/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
+++ b/Assets/Scripts/Games/BuiltToScaleDS/BuiltToScaleDS.cs
@@ -128,6 +128,10 @@ namespace HeavenStudio.Games
         {
             instance = this;
 
+            GameCamera.AdditionalPosition = camPos.position + (Quaternion.Euler(camPos.eulerAngles) * Vector3.forward * 10f);
+            GameCamera.AdditionalRotEuler = camPos.eulerAngles;
+            GameCamera.AdditionalFoV = cameraFoV;
+
             environmentMaterials = environmentRenderer.materials;
             elevatorMaterials = elevatorRenderer.materials;
             beltMaterial = Instantiate(environmentMaterials[8]);
@@ -189,13 +193,6 @@ namespace HeavenStudio.Games
             {
                 evt.Disable();
             }
-        }
-
-        private void Start()
-        {
-            GameCamera.additionalPosition = camPos.position + (Quaternion.Euler(camPos.eulerAngles) * Vector3.forward * 10f);
-            GameCamera.additionalRotEluer = camPos.eulerAngles;
-            GameCamera.additionalFoV = cameraFoV;
         }
 
         public void UpdateMappingColors(Color objectColor, Color shooterColor, Color environmentColor)

--- a/Assets/Scripts/Games/CheerReaders/CheerReaders.cs
+++ b/Assets/Scripts/Games/CheerReaders/CheerReaders.cs
@@ -290,39 +290,39 @@ namespace HeavenStudio.Games
                     {
                         if (normalizedZoomOutAgainBeat > 1)
                         {
-                            GameCamera.additionalPosition = new Vector3(0, 0, 0);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, 0);
                         }
                         else
                         {
                             Util.EasingFunction.Function func = Util.EasingFunction.GetEasingFunction(Util.EasingFunction.Ease.EaseInOutQuint);
                             float newZoom = func(shouldDoSuccessZoom ? 4f : 1.5f, 0, normalizedZoomOutAgainBeat);
-                            GameCamera.additionalPosition = new Vector3(0, 0, newZoom);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, newZoom);
                         }
                     }
                     else if (normalizedZoomInBeat >= 0)
                     {
                         if (normalizedZoomInBeat > 1)
                         {
-                            GameCamera.additionalPosition = new Vector3(0, 0, shouldDoSuccessZoom ? 4f : 1.5f);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, shouldDoSuccessZoom ? 4f : 1.5f);
                         }
                         else
                         {
                             Util.EasingFunction.Function func = Util.EasingFunction.GetEasingFunction(Util.EasingFunction.Ease.EaseOutQuint);
                             float newZoom = func(-1, shouldDoSuccessZoom ? 4f : 1.5f, normalizedZoomInBeat);
-                            GameCamera.additionalPosition = new Vector3(0, 0, newZoom);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, newZoom);
                         }
                     }
                     else if (normalizedZoomOutBeat >= 0)
                     {
                         if (normalizedZoomOutBeat > 1)
                         {
-                            GameCamera.additionalPosition = new Vector3(0, 0, -1);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, -1);
                         }
                         else
                         {
                             Util.EasingFunction.Function func = Util.EasingFunction.GetEasingFunction(Util.EasingFunction.Ease.EaseOutQuint);
                             float newZoom = func(0f, 1f, normalizedZoomOutBeat);
-                            GameCamera.additionalPosition = new Vector3(0, 0, newZoom * -1);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, newZoom * -1);
                         }
                     }
                 }

--- a/Assets/Scripts/Games/CropStomp/CropStomp.cs
+++ b/Assets/Scripts/Games/CropStomp/CropStomp.cs
@@ -425,7 +425,7 @@ namespace HeavenStudio.Games
             if (shakeTween != null)
                 shakeTween.Kill(true);
 
-            DOTween.Punch(() => GameCamera.additionalPosition, x => GameCamera.additionalPosition = x, new Vector3(0, 0.75f, 0), 
+            DOTween.Punch(() => GameCamera.AdditionalPosition, x => GameCamera.AdditionalPosition = x, new Vector3(0, 0.75f, 0), 
                 Conductor.instance.pitchedSecPerBeat*0.5f, 18, 1f);
 
             isStepping = true;

--- a/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
+++ b/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
@@ -287,7 +287,7 @@ namespace HeavenStudio.Games
                         {
                             currentXPos = flippersMovement.position.x + (moveLeft ? -rollDistance : rollDistance);
                             isMoving = true;
-                            currentCameraXPos = GameCamera.additionalPosition.x + (moveLeft ? -rollDistance : rollDistance);
+                            currentCameraXPos = GameCamera.AdditionalPosition.x + (moveLeft ? -rollDistance : rollDistance);
                             if (moveLeft)
                             {
                                 rightSnow.Play();
@@ -310,7 +310,7 @@ namespace HeavenStudio.Games
                         {
                             EasingFunction.Function funcCam = EasingFunction.GetEasingFunction(EasingFunction.Ease.EaseInOutQuad);
                             float newCameraPosX = funcCam(lastCameraXPos, currentCameraXPos, normalizedCamBeat);
-                            GameCamera.additionalPosition = new Vector3(newCameraPosX, 0, 0);
+                            GameCamera.AdditionalPosition = new Vector3(newCameraPosX, 0, 0);
                         }
                         if (1f >= normalizedBeat)
                         {

--- a/Assets/Scripts/Games/KarateMan/KarateMan.cs
+++ b/Assets/Scripts/Games/KarateMan/KarateMan.cs
@@ -839,7 +839,7 @@ namespace HeavenStudio.Games
             }
 
             BackgroundColorUpdate();
-            GameCamera.additionalPosition = cameraPosition - GameCamera.defaultPosition;
+            GameCamera.AdditionalPosition = cameraPosition - GameCamera.defaultPosition;
             BGEffect.transform.position = new Vector3(GameCamera.instance.transform.position.x, GameCamera.instance.transform.position.y, 0);
         }
 

--- a/Assets/Scripts/Games/Lockstep/Lockstep.cs
+++ b/Assets/Scripts/Games/Lockstep/Lockstep.cs
@@ -392,7 +392,7 @@ namespace HeavenStudio.Games
 
         public void SetZoom(int zoom)
         {
-            GameCamera.additionalPosition = new Vector3(0, 0, (ZoomPresets)zoom switch
+            GameCamera.AdditionalPosition = new Vector3(0, 0, (ZoomPresets)zoom switch
             {
                 ZoomPresets.Regular => 0,
                 ZoomPresets.NotThatFar => -4.5f,

--- a/Assets/Scripts/Games/RhythmRally/RhythmRally.cs
+++ b/Assets/Scripts/Games/RhythmRally/RhythmRally.cs
@@ -159,6 +159,9 @@ namespace HeavenStudio.Games
 
         private void Awake()
         {
+            GameCamera.AdditionalPosition = cameraPos.position + (Quaternion.Euler(cameraPos.rotation.eulerAngles) * Vector3.forward * 10f);
+            GameCamera.AdditionalRotEuler = cameraPos.rotation.eulerAngles;
+            GameCamera.AdditionalFoV = cameraFOV;
             instance = this;
             paddlers.Init();
 
@@ -367,9 +370,9 @@ namespace HeavenStudio.Games
             opponentServing = false;
 
             //update camera
-            GameCamera.additionalPosition = cameraPos.position + (Quaternion.Euler(cameraPos.rotation.eulerAngles) * Vector3.forward * 10f);
-            GameCamera.additionalRotEluer = cameraPos.rotation.eulerAngles;
-            GameCamera.additionalFoV = cameraFOV;
+            GameCamera.AdditionalPosition = cameraPos.position + (Quaternion.Euler(cameraPos.rotation.eulerAngles) * Vector3.forward * 10f);
+            GameCamera.AdditionalRotEuler = cameraPos.rotation.eulerAngles;
+            GameCamera.AdditionalFoV = cameraFOV;
         }
 
         public void Bop(double beat, float length, bool bop, bool bopAuto)

--- a/Assets/Scripts/Games/Ringside/Ringside.cs
+++ b/Assets/Scripts/Games/Ringside/Ringside.cs
@@ -293,11 +293,11 @@ namespace HeavenStudio.Games
                 {
                     if (normalizedShouldStopBeat > 1 && !keepZoomOut)
                     {
-                        GameCamera.additionalPosition = new Vector3(0, 0, 0);
+                        GameCamera.AdditionalPosition = new Vector3(0, 0, 0);
                     }
                     else if (normalizedBeat > 1)
                     {
-                        GameCamera.additionalPosition = new Vector3(currentCamPos.x, currentCamPos.y, currentCamPos.z + 10);
+                        GameCamera.AdditionalPosition = new Vector3(currentCamPos.x, currentCamPos.y, currentCamPos.z + 10);
                     }
                     else
                     {
@@ -305,7 +305,7 @@ namespace HeavenStudio.Games
                         float newPosX = func(lastCamPos.x, currentCamPos.x, normalizedBeat);
                         float newPosY = func(lastCamPos.y, currentCamPos.y, normalizedBeat);
                         float newPosZ = func(lastCamPos.z + 10, currentCamPos.z + 10, normalizedBeat);
-                        GameCamera.additionalPosition = new Vector3(newPosX, newPosY, newPosZ);
+                        GameCamera.AdditionalPosition = new Vector3(newPosX, newPosY, newPosZ);
                     }
                 }
             }

--- a/Assets/Scripts/Games/Rockers/Rockers.cs
+++ b/Assets/Scripts/Games/Rockers/Rockers.cs
@@ -670,7 +670,7 @@ namespace HeavenStudio.Games
                     Util.EasingFunction.Function func = Util.EasingFunction.GetEasingFunction(Util.EasingFunction.Ease.EaseInOutQuad);
 
                     float newX = func(lastTargetCameraX, targetCameraX, normalizedBeat);
-                    GameCamera.additionalPosition = new Vector3(newX, 0, 0);
+                    GameCamera.AdditionalPosition = new Vector3(newX, 0, 0);
                 }
             }
         }
@@ -680,7 +680,7 @@ namespace HeavenStudio.Games
             SoundByte.PlayOneShotGame("rockers/lastOne");
             if (moveCamera)
             {
-                lastTargetCameraX = GameCamera.additionalPosition.x;
+                lastTargetCameraX = GameCamera.AdditionalPosition.x;
                 targetCameraX = 0;
                 cameraMoveBeat = beat + 2;
             }
@@ -736,7 +736,7 @@ namespace HeavenStudio.Games
             SoundByte.PlayOneShotGame("rockers/cmon");
             if (moveCamera)
             {
-                lastTargetCameraX = GameCamera.additionalPosition.x;
+                lastTargetCameraX = GameCamera.AdditionalPosition.x;
                 targetCameraX = 0;
                 cameraMoveBeat = beat + 2;
             }
@@ -806,7 +806,7 @@ namespace HeavenStudio.Games
             List<BeatAction.Action> actions = new List<BeatAction.Action>();
             if (moveCamera)
             {
-                lastTargetCameraX = GameCamera.additionalPosition.x;
+                lastTargetCameraX = GameCamera.AdditionalPosition.x;
                 targetCameraX = 0;
                 cameraMoveBeat = beat + goToMiddleBeat;
             }
@@ -896,7 +896,7 @@ namespace HeavenStudio.Games
 
         private void MoveCamera(double beat)
         {
-            lastTargetCameraX = GameCamera.additionalPosition.x;
+            lastTargetCameraX = GameCamera.AdditionalPosition.x;
             targetCameraX = JJ.transform.localPosition.x;
             cameraMoveBeat = beat;
 
@@ -1058,7 +1058,7 @@ namespace HeavenStudio.Games
                     {
                         if (moveCamera)
                         {
-                            lastTargetCameraX = GameCamera.additionalPosition.x;
+                            lastTargetCameraX = GameCamera.AdditionalPosition.x;
                             targetCameraX = Soshi.transform.localPosition.x;
                             cameraMoveBeat = beat - 1;
                         }

--- a/Assets/Scripts/Games/SeeSaw/SeeSawGuy.cs
+++ b/Assets/Scripts/Games/SeeSaw/SeeSawGuy.cs
@@ -188,7 +188,7 @@ namespace HeavenStudio.Games.Scripts_SeeSaw
         public void Land(LandType landType, bool getUpOut)
         {
             transform.rotation = Quaternion.Euler(0, 0, 0);
-            GameCamera.additionalPosition = Vector3.zero;
+            GameCamera.AdditionalPosition = Vector3.zero;
             bool landedOut = false;
             switch (currentState)
             {

--- a/Assets/Scripts/Games/Spaceball/Spaceball.cs
+++ b/Assets/Scripts/Games/Spaceball/Spaceball.cs
@@ -165,27 +165,27 @@ namespace HeavenStudio.Games
                 {
                     if (normalizedBeat > 1)
                     {
-                        GameCamera.additionalPosition = new Vector3(0, 0, currentZoomCamDistance + 10);
+                        GameCamera.AdditionalPosition = new Vector3(0, 0, currentZoomCamDistance + 10);
                     }
                     else
                     {
                         if (currentZoomCamLength < 0)
                         {
-                            GameCamera.additionalPosition = new Vector3(0, 0, currentZoomCamDistance + 10);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, currentZoomCamDistance + 10);
                         }
                         else
                         {
                             Util.EasingFunction.Function func = Util.EasingFunction.GetEasingFunction(lastEase);
 
                             float newPosZ = func(lastCamDistance + 10, currentZoomCamDistance + 10, normalizedBeat);
-                            GameCamera.additionalPosition = new Vector3(0, 0, newPosZ);
+                            GameCamera.AdditionalPosition = new Vector3(0, 0, newPosZ);
                         }
                     }
                 }
                 else
                 {
                     // ?
-                    GameCamera.additionalPosition = new Vector3(0, 0, 0);
+                    GameCamera.AdditionalPosition = new Vector3(0, 0, 0);
                 }
             }
         }

--- a/Assets/Scripts/Games/TapTroupe/TapTroupe.cs
+++ b/Assets/Scripts/Games/TapTroupe/TapTroupe.cs
@@ -281,19 +281,19 @@ namespace HeavenStudio.Games
                 {
                     if (!keepZoomOut)
                     {
-                        GameCamera.additionalPosition = new Vector3(0, 0, 0);
+                        GameCamera.AdditionalPosition = new Vector3(0, 0, 0);
                         zoomOutAnim.Play("NoZoomOut", 0, 0);
                     }
                     else 
                     {
                         Util.EasingFunction.Function func = Util.EasingFunction.GetEasingFunction(lastEase);
                         if (normalizedBeat > 1)
-                            GameCamera.additionalPosition = new Vector3(0, 30, -100);
+                            GameCamera.AdditionalPosition = new Vector3(0, 30, -100);
                         else
                         {
                             float newPosY = func(0, 30, normalizedBeat);
                             float newPosZ = func(0, -100, normalizedBeat);
-                            GameCamera.additionalPosition = new Vector3(0, newPosY, newPosZ);
+                            GameCamera.AdditionalPosition = new Vector3(0, newPosY, newPosZ);
                         }
                         if (normalizedAnimBeat > 1)
                         {

--- a/Assets/Scripts/Games/TapTroupe/TapTroupeZoomOut.cs
+++ b/Assets/Scripts/Games/TapTroupe/TapTroupeZoomOut.cs
@@ -17,7 +17,7 @@ namespace HeavenStudio.Games.Scripts_TapTroupe
 
         void Update()
         {
-            transform.localPosition = new Vector3(transform.localPosition.x, GameCamera.additionalPosition.y + yOffset, GameCamera.additionalPosition.z + zoomOffset);
+            transform.localPosition = new Vector3(transform.localPosition.x, GameCamera.AdditionalPosition.y + yOffset, GameCamera.AdditionalPosition.z + zoomOffset);
         }
     }
 }

--- a/Assets/Scripts/StaticCamera.cs
+++ b/Assets/Scripts/StaticCamera.cs
@@ -86,6 +86,10 @@ namespace HeavenStudio
             UpdatePan();
             UpdateRotation();
             UpdateScale();
+
+            canvas.localPosition = pan;
+            canvas.eulerAngles = new Vector3(0, 0, rotation);
+            canvas.localScale = scale;
         }
 
         // Update is called once per frame


### PR DESCRIPTION
- Fixed GameCamera.AdditionalPosition being delayed by 1 frame, causing multiple issues including a 1 frame jumpscare when Rhythm Rally and BTSDS are instanced.
- Fixed the viewport values not being applied to the canvas in the onBeatChanged callback