### PR TITLE
Screen Tiling Split into two events + Some tweaks and new vfx!

### DIFF
--- a/Assets/Resources/Prefabs/GameView/CamerasEditor.prefab
+++ b/Assets/Resources/Prefabs/GameView/CamerasEditor.prefab
@@ -93,6 +93,9 @@ MonoBehaviour:
   ambientBg: {fileID: 5129120947114944961}
   ambientBgGO: {fileID: 269805006432045765}
   letterboxBgGO: {fileID: 3741076794236313655}
+  overlayCanvas: {fileID: 8512930684284350359}
+  letterboxMask: {fileID: 8925473620302868482}
+  parentView: {fileID: 2077856143944097172}
   camera: {fileID: 378821074852065722}
 --- !u!1 &269805006432045765
 GameObject:

--- a/Assets/Scripts/Games/AirRally/AirRally.cs
+++ b/Assets/Scripts/Games/AirRally/AirRally.cs
@@ -1049,11 +1049,11 @@ namespace HeavenStudio.Games
                 SetDistance(distanceEvent.beat, distanceEvent["type"], distanceEvent["ease"]);
             }
 
-            if (wantStartRally >= beat && IsRallyBeat(wantStartRally))
+            if (wantStartRally >= beat && IsRallyBeat(wantStartRally) && wantStartRally < nextGameSwitchBeatGlobal)
             {
                 StartRally(wantStartRally);
             }
-            else if (wantStartBaBum >= beat && IsBaBumBeat(wantStartBaBum))
+            else if (wantStartBaBum >= beat && IsBaBumBeat(wantStartBaBum) && wantStartBaBum < nextGameSwitchBeatGlobal)
             {
                 StartBaBumBumBum(wantStartBaBum, wantCount, wantAlt);
             }

--- a/Assets/Scripts/Games/QuizShow/QuizShow.cs
+++ b/Assets/Scripts/Games/QuizShow/QuizShow.cs
@@ -573,16 +573,7 @@ namespace HeavenStudio.Games
                     ScheduleAutoplayInput(beat, length + inputBeat, InputAction_Right, AutoplayAButton, Nothing, Nothing);
                 }
             }
-
-            if (doingConsectiveIntervals)
-            {
-                countToMatch += relevantInputs.Count;
-            }
-            else
-            {
-                countToMatch = relevantInputs.Count;
-            }
-            int hundredLoops = Mathf.FloorToInt(countToMatch / 100);
+            int hundredLoops = Mathf.FloorToInt((float)countToMatch / 100f);
             countToMatch -= hundredLoops * 100;
             doingConsectiveIntervals = consecutive;
             float timeUpBeat = 0f;
@@ -598,6 +589,14 @@ namespace HeavenStudio.Games
             {
                 new BeatAction.Action(beat, delegate
                 {
+                    if (doingConsectiveIntervals)
+                    {
+                        countToMatch += relevantInputs.Count;
+                    }
+                    else
+                    {
+                        countToMatch = relevantInputs.Count;
+                    }
                     if (shouldPrepareArms)
                     {
                         contesteeLeftArmAnim.DoScaledAnimationAsync("LeftPrepare", 0.5f);

--- a/Assets/Scripts/Games/Splashdown/NtrSynchrette.cs
+++ b/Assets/Scripts/Games/Splashdown/NtrSynchrette.cs
@@ -124,10 +124,10 @@ namespace HeavenStudio.Games.Scripts_Splashdown
             Instantiate(splashPrefab, splashHolder).Init("Appearsplash");
         }
 
-        public void GoDown()
+        public void GoDown(bool splash = true)
         {
             SetState(MovementState.Dive, startBeat);
-            Instantiate(splashPrefab, splashHolder).Init("GodownSplash");
+            if (splash) Instantiate(splashPrefab, splashHolder).Init("GodownSplash");
         }
 
         public void Bop()

--- a/Assets/Scripts/Games/TossBoys/TossBoys.cs
+++ b/Assets/Scripts/Games/TossBoys/TossBoys.cs
@@ -169,7 +169,7 @@ namespace HeavenStudio.Games
 
         protected static bool IA_TouchNrm(out double dt)
         {
-            return PlayerInput.GetFlick(out dt)
+            return PlayerInput.GetTouchDown(InputController.ActionsTouch.Tap, out dt)
                 && (instance.currentReceiver is WhichTossKid.Akachan
                     || (instance.lastReceiver is WhichTossKid.Akachan or WhichTossKid.None
                         && instance.currentReceiver is WhichTossKid.None)
@@ -178,7 +178,7 @@ namespace HeavenStudio.Games
         }
         protected static bool IA_TouchDir(out double dt)
         {
-            return PlayerInput.GetFlick(out dt)
+            return PlayerInput.GetTouchDown(InputController.ActionsTouch.Tap, out dt)
                 && (instance.currentReceiver is WhichTossKid.Kiiyan
                     || (instance.lastReceiver is WhichTossKid.Kiiyan
                         && instance.currentReceiver is WhichTossKid.None)
@@ -187,7 +187,7 @@ namespace HeavenStudio.Games
         }
         protected static bool IA_TouchAlt(out double dt)
         {
-            return PlayerInput.GetFlick(out dt)
+            return PlayerInput.GetTouchDown(InputController.ActionsTouch.Tap, out dt)
                 && (instance.currentReceiver is WhichTossKid.Aokun
                     || (instance.lastReceiver is WhichTossKid.Aokun
                         && instance.currentReceiver is WhichTossKid.None)
@@ -276,44 +276,6 @@ namespace HeavenStudio.Games
             BackgroundColorUpdate();
             if (cond.isPlaying && !cond.isPaused)
             {
-                if (PlayerInput.CurrentControlStyle == InputController.ControlStyles.Touch)
-                {
-                    TossKid next = GetCurrentReceiver();
-                    if (currentReceiver == WhichTossKid.None && lastReceiver != WhichTossKid.None)
-                    {
-                        next = GetReceiver(lastReceiver);
-                    }
-                    else if (currentReceiver == WhichTossKid.None && lastReceiver == WhichTossKid.None)
-                    {
-                        next = akachan;
-                    }
-                    if (PlayerInput.GetIsAction(InputAction_BasicPress))
-                    {
-                        if (currentBall != null && next != null)
-                        {
-                            if (currentBall.willBePopped)
-                            {
-                                next.PopBallPrepare();
-                            }
-                            else
-                            {
-                                next.Crouch();
-                            }
-                        }
-                        else if (next != null)
-                        {
-                            next.Crouch();
-                        }
-                    }
-                    else if (PlayerInput.GetIsAction(InputAction_BasicRelease))
-                    {
-                        if (next != null)
-                        {
-                            next.UnCrouch();
-                        }
-                    }
-                }
-
                 if (PlayerInput.GetIsAction(InputAction_Aka) && !IsExpectingInputNow(InputAction_Aka))
                 {
                     akachan.HitBall(false);

--- a/Assets/Scripts/Games/TossBoys/TossKid.cs
+++ b/Assets/Scripts/Games/TossBoys/TossKid.cs
@@ -41,7 +41,7 @@ namespace HeavenStudio.Games.Scripts_TossBoys
 
         public void Bop()
         {
-            if (crouch || preparing) return;
+            if (crouch || preparing || (!anim.IsAnimationNotPlaying() && !anim.IsPlayingAnimationName(prefix + "Idle"))) return;
             DoAnimationScaledAsync("Bop", 0.5f);
         }
 

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -1025,7 +1025,7 @@ namespace HeavenStudio
                             }),
                         }
                     },
-                    new GameAction("screenTiling", "Screen Tiling")
+                    new GameAction("screenTiling", "Tile Screen")
                     {
                         resizable = true,
                         parameters = new()
@@ -1034,15 +1034,26 @@ namespace HeavenStudio
                             new("yStart", new EntityTypes.Float(1, 100, 1), "Start Vertical Tiles"),
                             new("xEnd", new EntityTypes.Float(1, 100, 1), "End Horizontal Tiles"),
                             new("yEnd", new EntityTypes.Float(1, 100, 1), "End Vertical Tiles"),
-
+                            new Param("axis", StaticCamera.ViewAxis.All, "Axis"),
+                            new("ease", Util.EasingFunction.Ease.Linear, "Ease", "", new()
+                            {
+                                new((x, y) => (Util.EasingFunction.Ease)x != Util.EasingFunction.Ease.Instant, new string[] { "xStart", "yStart" })
+                            }),
+                        }
+                    },
+                    new GameAction("scrollTiles", "Scroll Tiles")
+                    {
+                        resizable = true,
+                        parameters = new()
+                        {
                             new("xScrollStart", new EntityTypes.Float(-100, 100, 0), "Start Horizontal Scroll"),
                             new("yScrollStart", new EntityTypes.Float(-100, 100, 0), "Start Vertical Scroll"),
                             new("xScrollEnd", new EntityTypes.Float(-100, 100, 0), "End Horizontal Scroll"),
                             new("yScrollEnd", new EntityTypes.Float(-100, 100, 0), "End Vertical Scroll"),
-
+                            new Param("axis", StaticCamera.ViewAxis.All, "Axis"),
                             new("ease", Util.EasingFunction.Ease.Linear, "Ease", "", new()
                             {
-                                new((x, y) => (Util.EasingFunction.Ease)x != Util.EasingFunction.Ease.Instant, new string[] { "xStart", "yStart", "xScrollStart", "yScrollStart" })
+                                new((x, y) => (Util.EasingFunction.Ease)x != Util.EasingFunction.Ease.Instant, new string[] { "xScrollStart", "yScrollStart" })
                             }),
                         }
                     }

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -1025,6 +1025,14 @@ namespace HeavenStudio
                             }),
                         }
                     },
+                    new GameAction("fitScreen", "Fit Game To Screen")
+                    {
+                        defaultLength = 0.5f,
+                        parameters = new()
+                        {
+                            new("enable", true, "Enabled")
+                        }
+                    },
                     new GameAction("screenTiling", "Tile Screen")
                     {
                         resizable = true,

--- a/Assets/Scripts/StaticCamera.cs
+++ b/Assets/Scripts/StaticCamera.cs
@@ -21,6 +21,10 @@ namespace HeavenStudio
         [SerializeField] GameObject ambientBgGO;
         [SerializeField] GameObject letterboxBgGO;
 
+        [SerializeField] RectTransform overlayCanvas;
+        [SerializeField] RectTransform letterboxMask;
+        [SerializeField] RectTransform parentView;
+
         public static StaticCamera instance { get; private set; }
         public new Camera camera;
 
@@ -37,6 +41,7 @@ namespace HeavenStudio
         private List<RiqEntity> panEvents = new();
         private List<RiqEntity> scaleEvents = new();
         private List<RiqEntity> rotationEvents = new();
+        private List<RiqEntity> fitScreenEvents = new();
 
         static Vector3 defaultPan = new Vector3(0, 0, 0);
         static Vector3 defaultScale = new Vector3(1, 1, 1);
@@ -78,6 +83,7 @@ namespace HeavenStudio
             panEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "pan view" });
             scaleEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "scale view" });
             rotationEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "rotate view" });
+            fitScreenEvents = EventCaller.GetAllInGameManagerList("vfx", new string[] { "fitScreen" });
 
             panLast = defaultPan;
             scaleLast = defaultScale;
@@ -86,6 +92,7 @@ namespace HeavenStudio
             UpdatePan();
             UpdateRotation();
             UpdateScale();
+            UpdateGameScreenFit();
 
             canvas.localPosition = pan;
             canvas.eulerAngles = new Vector3(0, 0, rotation);
@@ -98,10 +105,32 @@ namespace HeavenStudio
             UpdatePan();
             UpdateRotation();
             UpdateScale();
+            UpdateGameScreenFit();
 
             canvas.localPosition = pan;
             canvas.eulerAngles = new Vector3(0, 0, rotation);
             canvas.localScale = scale;
+        }
+
+        private void UpdateGameScreenFit()
+        {
+            var curBeat = Conductor.instance.songPositionInBeatsAsDouble;
+            letterboxMask.localScale = new Vector3(1, 1, 1);
+            overlayCanvas.localScale = new Vector3(1, 1, 1);
+            foreach (var e in fitScreenEvents)
+            {
+                if (curBeat < e.beat) break;
+                if (e["enable"])
+                {
+                    letterboxMask.localScale = new Vector3(parentView.sizeDelta.x / 16, parentView.sizeDelta.y / 9, 1);
+                    overlayCanvas.localScale = new Vector3(parentView.sizeDelta.x / 16, parentView.sizeDelta.y / 9, 1);
+                }
+                else
+                {
+                    letterboxMask.localScale = new Vector3(1, 1, 1);
+                    overlayCanvas.localScale = new Vector3(1, 1, 1);
+                }
+            }
         }
 
         private void UpdatePan()


### PR DESCRIPTION
VFX:
- Added new vfx event that "removes" the letterbox by making the game fit your screen (Credit goes to firerise for that mostly)
- Split screen tiling into two events: Tile Screen and Scroll Tiles

Toss Boys:
- Fixed a bug with bops
- Made the game be controlled with tap instead of flick in touch mode

See Saw:
- Fixed bug where landing sound would play after game switch
- See now jumps high up before a high jump like the original
- Made the start jump sound not trigger immediately on game switch if it was supposed to play earlier, then it just is silent

Quiz Show:
- Fixed a bug where the amount of inputs needed would be changed 2 beats before an interval

Splashdown:
- Synchrettes spawned while diving will now enter the world under the water