### PR TITLE
Stretch Camera VFX Event + Fixes

### DIFF
--- a/Assets/Scenes/Editor.unity
+++ b/Assets/Scenes/Editor.unity
@@ -371,9 +371,9 @@ RectTransform:
   m_Father: {fileID: 574002313}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -21}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &9435782
@@ -3519,9 +3519,9 @@ RectTransform:
   m_Father: {fileID: 539838476}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 32, y: -21}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!114 &121871281
@@ -3664,9 +3664,9 @@ RectTransform:
   m_Father: {fileID: 539838476}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 72, y: -21}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!114 &129013734
@@ -3786,9 +3786,9 @@ RectTransform:
   m_Father: {fileID: 539838476}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 112, y: -21}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!114 &151246938
@@ -30195,9 +30195,9 @@ RectTransform:
   m_Father: {fileID: 574002313}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 40, y: -21}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &1345846031
@@ -38052,9 +38052,9 @@ RectTransform:
   m_Father: {fileID: 574002313}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 80, y: -21}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 32, y: 32}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &1783491359
@@ -41644,6 +41644,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1981150263}
   m_CullTransparentMesh: 1
+--- !u!1 &1981736777
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1981736779}
+  - component: {fileID: 1981736778}
+  m_Layer: 0
+  m_Name: StretchCameraVFX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1981736778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981736777}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c41d0b7047b9b1d4e91d4cf101fa025b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1981736779
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981736777}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1987174610
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -969,7 +969,9 @@ namespace HeavenStudio
             {
                 _currentMinigame = minigame;
             }
+            Vector3 originalScale = currentGameO.transform.localScale;
             currentGameO.transform.parent = eventCaller.GamesHolder.transform;
+            currentGameO.transform.localScale = originalScale;
             currentGameO.name = game;
 
             SetCurrentGame(game, useMinigameColor);

--- a/Assets/Scripts/Games/BlueBear/BlueBear.cs
+++ b/Assets/Scripts/Games/BlueBear/BlueBear.cs
@@ -221,18 +221,6 @@ namespace HeavenStudio.Games
             return default(SuperCurveObject.Path);
         }
 
-        void OnDestroy()
-        {
-            foreach (var evt in scheduledInputs)
-            {
-                evt.Disable();
-            }
-            if (Conductor.instance.isPlaying || Conductor.instance.isPaused) return;
-            rightCrumbAppearThreshold = 15;
-            leftCrumbAppearThreshold = 30;
-            eatenTreats = 0;
-        }
-
         private void Awake()
         {
             instance = this;
@@ -357,7 +345,7 @@ namespace HeavenStudio.Games
             if (_allEmotionsStretch.Count == 0) return;
             UpdateEmotions();
             var allEmosBeforeBeat = EventCaller.GetAllInGameManagerList("blueBear", new string[] { "stretchEmotion" }).FindAll(x => x.beat < beat);
-
+            if (allEmosBeforeBeat.Count == 0) return;
             if ((EmotionStretchType)allEmosBeforeBeat[^1]["type"] == EmotionStretchType.StartCrying)
             {
                 headAndBodyAnim.DoScaledAnimationAsync("CryIdle", 0.5f);

--- a/Assets/Scripts/Games/GleeClub/ChorusKid.cs
+++ b/Assets/Scripts/Games/GleeClub/ChorusKid.cs
@@ -74,7 +74,7 @@ namespace HeavenStudio.Games.Scripts_GleeClub
             anim.SetBool("Mega", true);
             anim.Play("OpenMouth", 0, 0);
             shouldMegaClose = true;
-            if (currentSound != null) SoundByte.KillLoop(currentSound, 0f);
+            if (currentSound != null) currentSound.Stop();
             SoundByte.PlayOneShotGame("gleeClub/LoudWailStart");
             currentSound = SoundByte.PlayOneShotGame("gleeClub/LoudWailLoop", -1, currentPitch, 1f, true);
             BeatAction.New(game, new List<BeatAction.Action>()
@@ -95,7 +95,7 @@ namespace HeavenStudio.Games.Scripts_GleeClub
             anim.SetBool("Mega", false);
             shouldMegaClose = false;
             anim.Play("OpenMouth", 0, 0);
-            if (currentSound != null) SoundByte.KillLoop(currentSound, 0f);
+            if (currentSound != null) currentSound.Stop();
             currentSound = SoundByte.PlayOneShotGame("gleeClub/WailLoop", -1, currentPitch, 1f, true);
         }
 
@@ -104,7 +104,7 @@ namespace HeavenStudio.Games.Scripts_GleeClub
             if (!singing || disappeared) return;
             singing = false;
             anim.Play(mega ? "MegaCloseMouth" : "CloseMouth", 0, 0);
-            if (currentSound != null) SoundByte.KillLoop(currentSound, 0f);
+            if (currentSound != null) currentSound.Stop();
             if (playSound) SoundByte.PlayOneShotGame("gleeClub/StopWail");
         }
     }

--- a/Assets/Scripts/Games/TossBoys/TossBoys.cs
+++ b/Assets/Scripts/Games/TossBoys/TossBoys.cs
@@ -1065,8 +1065,7 @@ namespace HeavenStudio.Games
             if (currentSpecialKid != null) currentSpecialKid.crouch = false;
             currentSpecialKid = GetCurrentReceiver();
 
-            if (PlayerInput.CurrentControlStyle != InputController.ControlStyles.Touch)
-                GetCurrentReceiver().Crouch();
+            GetCurrentReceiver().Crouch();
 
             GetSpecialBasedOnReceiver().SetActive(true);
             switch (currentReceiver)

--- a/Assets/Scripts/Games/TossBoys/TossKid.cs
+++ b/Assets/Scripts/Games/TossBoys/TossKid.cs
@@ -35,7 +35,6 @@ namespace HeavenStudio.Games.Scripts_TossBoys
                 DoAnimationScaledAsync("Whiff", 0.5f);
                 SoundByte.PlayOneShotGame("tossBoys/whiff");
             }
-            crouch = false;
             preparing = false;
         }
 
@@ -49,12 +48,6 @@ namespace HeavenStudio.Games.Scripts_TossBoys
         {
             DoAnimationScaledAsync("Crouch", 0.5f);
             crouch = true;
-        }
-
-        public void UnCrouch()
-        {
-            DoAnimationScaledAsync("Idle", 1f);
-            crouch = false;
         }
 
         public void PopBall()

--- a/Assets/Scripts/Minigames.cs
+++ b/Assets/Scripts/Minigames.cs
@@ -818,6 +818,22 @@ namespace HeavenStudio
                             new Param("axis", GameCamera.CameraAxis.All, "Axis", "The axis to move the camera on" )
                         }
                     ),
+                    new("stretch camera", "Stretch Camera")
+                    {
+                        resizable = true,
+                        parameters = new()
+                        {
+                            new("x1", new EntityTypes.Float(0f, 50f, 1f), "Start Width"),
+                            new("y1", new EntityTypes.Float(0f, 50f, 1f), "Start Height"),
+                            new("x2", new EntityTypes.Float(0f, 50f, 1f), "End Width"),
+                            new("y2", new EntityTypes.Float(0f, 50f, 1f), "End Height"),
+                            new("ease", Util.EasingFunction.Ease.Linear, "Ease", "", new()
+                            {
+                                new((x, y) => (Util.EasingFunction.Ease)x != Util.EasingFunction.Ease.Instant, new string[] { "x1", "y1" })
+                            }),
+                            new Param("axis", GameCamera.CameraAxis.All, "Axis")
+                        }
+                    },
                     new GameAction("camera background color", "Camera Background Color", 1, true, new List<Param>()
                         {
                             new Param("color", Color.black, "Start Color"),

--- a/Assets/Scripts/StretchCameraVFX.cs
+++ b/Assets/Scripts/StretchCameraVFX.cs
@@ -1,0 +1,52 @@
+using Jukebox;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HeavenStudio
+{
+    public class StretchCameraVFX : MonoBehaviour
+    {
+        private List<RiqEntity> _events = new();
+
+        private void Start()
+        {
+            GameManager.instance.onBeatChanged += OnBeatChanged;
+        }
+
+        public void OnBeatChanged(double beat)
+        {
+            _events = EventCaller.GetAllInGameManagerList("vfx", new string[] { "stretch camera" });
+            Update();
+        }
+
+        private void Update()
+        {
+            float newX = 1f;
+            float newY = 1f;
+            foreach (var e in _events)
+            {
+                float normalized = Conductor.instance.GetPositionFromBeat(e.beat, e.length);
+                if (normalized < 0f) break;
+                float clampNormal = Mathf.Clamp01(normalized);
+                var func = Util.EasingFunction.GetEasingFunction((Util.EasingFunction.Ease)e["ease"]);
+
+                switch ((StaticCamera.ViewAxis)e["axis"])
+                {
+                    case StaticCamera.ViewAxis.All:
+                        newX = func(e["x1"], e["x2"], clampNormal);
+                        newY = func(e["y1"], e["y2"], clampNormal);
+                        break;
+                    case StaticCamera.ViewAxis.X:
+                        newX = func(e["x1"], e["x2"], clampNormal);
+                        break;
+                    case StaticCamera.ViewAxis.Y:
+                        newY = func(e["y1"], e["y2"], clampNormal);
+                        break;
+                }
+            }
+            EventCaller.instance.GamesHolder.transform.localScale = new Vector3(newX, newY, 1f);
+        }
+    }
+}
+

--- a/Assets/Scripts/StretchCameraVFX.cs.meta
+++ b/Assets/Scripts/StretchCameraVFX.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c41d0b7047b9b1d4e91d4cf101fa025b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
VFX:
- Added a new VFX event "Stretch Camera", stretches the game camera (or is an illusion of it). This is useful for combining it with viewport scaling and screen tiling

Blue Bear:
- Fixed Long Emotions freezing up the editor

Glee Club:
- Fixed fade out working really weirdly

Toss Boys:
- Fixed toss kids uncrouching when they should be crouched