### PR TITLE
IsPlayingAnimationName() -> IsPlayingAnimationNames()

### DIFF
--- a/Assets/Scripts/Games/GleeClub/ChorusKid.cs
+++ b/Assets/Scripts/Games/GleeClub/ChorusKid.cs
@@ -58,7 +58,7 @@ namespace HeavenStudio.Games.Scripts_GleeClub
 
         public void MissPose()
         {
-            if (!singing && anim.GetCurrentAnimatorStateInfo(0).IsName("Idle") && !anim.IsPlayingAnimationName("MissIdle")) anim.Play("MissIdle", 0, 0);
+            if (!singing && anim.GetCurrentAnimatorStateInfo(0).IsName("Idle") && !anim.IsPlayingAnimationNames("MissIdle")) anim.Play("MissIdle", 0, 0);
         }
 
         public void StartCrouch()

--- a/Assets/Scripts/Games/LaunchParty/LaunchPartyRocket.cs
+++ b/Assets/Scripts/Games/LaunchParty/LaunchPartyRocket.cs
@@ -37,7 +37,7 @@ namespace HeavenStudio.Games.Scripts_LaunchParty
                 SoundByte.PlayOneShotGame("launchParty/miss");
                 SoundByte.PlayOneShotGame("launchParty/rocket_endBad");
                 string leftOrRight = (UnityEngine.Random.Range(1, 3) == 1) ? "Left" : "Right";
-                if (!anim.IsPlayingAnimationName("RocketBarelyLeft") && !anim.IsPlayingAnimationName("RocketBarelyRight")) anim.Play("RocketBarely" + leftOrRight, 0, 0);
+                if (!anim.IsPlayingAnimationNames("RocketBarelyLeft", "RocketBarelyRight")) anim.Play("RocketBarely" + leftOrRight, 0, 0);
                 game.ScoreMiss(0.5);
             }
         }
@@ -167,7 +167,7 @@ namespace HeavenStudio.Games.Scripts_LaunchParty
         void JustFamilyRocket(PlayerActionEvent caller, float state)
         {
             noInput = true;
-            if (anim.IsPlayingAnimationName("RocketBarelyLeft") || anim.IsPlayingAnimationName("RocketBarelyRight")) 
+            if (anim.IsPlayingAnimationNames("RocketBarelyLeft", "RocketBarelyRight"))
             {
                 number.SetActive(false);
                 anim.SetBool("CanRise", false);
@@ -213,7 +213,7 @@ namespace HeavenStudio.Games.Scripts_LaunchParty
         void JustPartyCracker(PlayerActionEvent caller, float state)
         {
             noInput = true;
-            if (anim.IsPlayingAnimationName("RocketBarelyLeft") || anim.IsPlayingAnimationName("RocketBarelyRight"))
+            if (anim.IsPlayingAnimationNames("RocketBarelyLeft", "RocketBarelyRight"))
             {
                 number.SetActive(false);
                 anim.SetBool("CanRise", false);
@@ -257,7 +257,7 @@ namespace HeavenStudio.Games.Scripts_LaunchParty
         void JustBell(PlayerActionEvent caller, float state)
         {
             noInput = true;
-            if (anim.IsPlayingAnimationName("RocketBarelyLeft") || anim.IsPlayingAnimationName("RocketBarelyRight"))
+            if (anim.IsPlayingAnimationNames("RocketBarelyLeft", "RocketBarelyRight"))
             {
                 number.SetActive(false);
                 anim.SetBool("CanRise", false);
@@ -301,7 +301,7 @@ namespace HeavenStudio.Games.Scripts_LaunchParty
         void JustBowlingPin(PlayerActionEvent caller, float state)
         {
             noInput = true;
-            if (anim.IsPlayingAnimationName("RocketBarelyLeft") || anim.IsPlayingAnimationName("RocketBarelyRight"))
+            if (anim.IsPlayingAnimationNames("RocketBarelyLeft", "RocketBarelyRight"))
             {
                 number.SetActive(false);
                 anim.SetBool("CanRise", false);

--- a/Assets/Scripts/Games/MeatGrinder/MeatGrinder.cs
+++ b/Assets/Scripts/Games/MeatGrinder/MeatGrinder.cs
@@ -158,8 +158,8 @@ namespace HeavenStudio.Games
 
         public override void OnBeatPulse(double beat)
         {
-            if (!BossAnim.IsPlayingAnimationName("BossCall")
-                && !BossAnim.IsPlayingAnimationName("BossSignal")
+            if (!BossAnim.IsPlayingAnimationNames("BossCall")
+                && !BossAnim.IsPlayingAnimationNames("BossSignal")
                 && BeatIsInBopRegion(beat))
             {
                 BossAnim.DoScaledAnimationAsync(bossAnnoyed ? "BossMiss" : "Bop", 0.5f);
@@ -174,7 +174,7 @@ namespace HeavenStudio.Games
                 {
                     BeatAction.New(instance, new List<BeatAction.Action>() {
                         new BeatAction.Action(beat + i, delegate {
-                            if (!BossAnim.IsPlayingAnimationName("BossCall") && !BossAnim.IsPlayingAnimationName("BossSignal")) {
+                            if (!BossAnim.IsPlayingAnimationNames("BossCall") && !BossAnim.IsPlayingAnimationNames("BossSignal")) {
                                 BossAnim.DoScaledAnimationAsync(bossAnnoyed ? "BossMiss" : "Bop", 0.5f);
                             }
                         })

--- a/Assets/Scripts/Games/MeatGrinder/MeatToss.cs
+++ b/Assets/Scripts/Games/MeatGrinder/MeatToss.cs
@@ -38,7 +38,7 @@ namespace HeavenStudio.Games.Scripts_MeatGrinder
 
         private void Update()
         {
-            if (anim.IsPlayingAnimationName("DarkIdle") || anim.IsPlayingAnimationName("LightIdle")) GameObject.Destroy(gameObject);
+            if (anim.IsPlayingAnimationNames("DarkIdle") || anim.IsPlayingAnimationNames("LightIdle")) GameObject.Destroy(gameObject);
         }
         
         private void InputActions(bool annoyBoss, string whichSfx, string whichAnim)

--- a/Assets/Scripts/Games/MunchyMonk/MunchyMonk.cs
+++ b/Assets/Scripts/Games/MunchyMonk/MunchyMonk.cs
@@ -287,13 +287,10 @@ namespace HeavenStudio.Games
             }
 
             // blushes when done eating but not when staring
-            if (needBlush 
-                && !MonkAnim.IsPlayingAnimationName("Eat")
-                && !MonkAnim.IsPlayingAnimationName("Stare")
-                && !MonkAnim.IsPlayingAnimationName("Barely")
-                && !MonkAnim.IsPlayingAnimationName("Miss")
+            if (needBlush
+                && !MonkAnim.IsPlayingAnimationNames("Eat", "Stare", "Barely", "Miss")
                 && !isStaring
-                && !noBlush) 
+                && !noBlush)
             {
                 MonkAnim.DoScaledAnimationAsync("Blush", 0.5f);
                 needBlush = false;
@@ -351,14 +348,14 @@ namespace HeavenStudio.Games
 
         public override void OnBeatPulse(double beat)
         {
-            if ((MonkAnim.IsAnimationNotPlaying() || MonkAnim.IsPlayingAnimationName("Bop") || MonkAnim.IsPlayingAnimationName("Idle"))
+            if ((MonkAnim.IsAnimationNotPlaying() || MonkAnim.IsPlayingAnimationNames("Bop", "Idle"))
                 && BeatIsInBopRegion(beat)
                 && !isStaring)
             {
                 MonkAnim.DoScaledAnimationAsync("Bop", 0.5f);
             }
 
-            if (!MonkAnim.IsPlayingAnimationName("Blush") || !MonkAnim.IsPlayingAnimationName("Stare"))
+            if (!MonkAnim.IsPlayingAnimationNames("Blush", "Stare"))
             {
                 if (growLevel == 4) BrowAnim.DoScaledAnimationAsync("Bop", 0.5f);
                 if (growLevel > 0) StacheAnim.DoScaledAnimationAsync($"Bop{growLevel}", 0.5f);

--- a/Assets/Scripts/Games/OctopusMachine/Octopus.cs
+++ b/Assets/Scripts/Games/OctopusMachine/Octopus.cs
@@ -31,7 +31,7 @@ namespace HeavenStudio.Games.Scripts_OctopusMachine
         void Update()
         {
             if (queuePrepare <= Conductor.instance.songPositionInBeatsAsDouble && Conductor.instance.NotStopped()) {
-                if (!(isPreparing || isSqueezed || anim.IsPlayingAnimationName("Release") || anim.IsPlayingAnimationName("Pop"))) 
+                if (!(isPreparing || isSqueezed || anim.IsPlayingAnimationNames("Release", "Pop"))) 
                 {
                     anim.DoScaledAnimationFromBeatAsync("Prepare", 0.5f, queuePrepare);
                     isPreparing = true;
@@ -66,15 +66,7 @@ namespace HeavenStudio.Games.Scripts_OctopusMachine
 
         public void RequestBop()
         {
-            if (!anim.IsPlayingAnimationName("Bop")
-                && !anim.IsPlayingAnimationName("Happy")
-                && !anim.IsPlayingAnimationName("Angry")
-                && !anim.IsPlayingAnimationName("Oops")
-                && !anim.IsPlayingAnimationName("Release")
-                && !anim.IsPlayingAnimationName("Pop")
-                && !isPreparing
-                && !isSqueezed
-                && !cantBop)
+            if (!anim.IsPlayingAnimationNames("Bop", "Happy", "Angry", "Oops", "Release", "Pop") && !isPreparing && !isSqueezed && !cantBop)
             {
                 PlayAnimation(game.bopStatus);
             }

--- a/Assets/Scripts/Games/Ringside/Ringside.cs
+++ b/Assets/Scripts/Games/Ringside/Ringside.cs
@@ -248,7 +248,7 @@ namespace HeavenStudio.Games
 
                         wrestlerAnim.DoScaledAnimationAsync("YeMiss", 0.25f);
                         SoundByte.PlayOneShotGame($"ringside/confusedanswer");
-                        if (reporterAnim.IsPlayingAnimationName("IdleReporter")) reporterAnim.Play("IdleLate", 0, 0);
+                        if (reporterAnim.IsPlayingAnimationNames("IdleReporter")) reporterAnim.Play("IdleLate", 0, 0);
                     }
                 }
                 if ( PlayerInput.CurrentControlStyle == InputController.ControlStyles.Touch

--- a/Assets/Scripts/Games/SpaceDance/SpaceDance.cs
+++ b/Assets/Scripts/Games/SpaceDance/SpaceDance.cs
@@ -266,7 +266,7 @@ namespace HeavenStudio.Games
                         }
                     }
                 }
-                if (!DancerP.IsPlayingAnimationName("PunchDo") && !DancerP.IsPlayingAnimationName("TurnRightDo") && !DancerP.IsPlayingAnimationName("SitDownDo"))
+                if (!DancerP.IsPlayingAnimationNames("PunchDo", "TurnRightDo", "SitDownDo"))
                 {
                     if (PlayerInput.GetIsAction(InputAction_Punch) && !IsExpectingInputNow(InputAction_Punch))
                     {

--- a/Assets/Scripts/Games/TapTroupe/TapTroupeCorner.cs
+++ b/Assets/Scripts/Games/TapTroupe/TapTroupeCorner.cs
@@ -38,7 +38,7 @@ namespace HeavenStudio.Games.Scripts_TapTroupe
 
         public void ResetFace()
         {
-            if (expressionAnim.IsPlayingAnimationName("Okay")) return;
+            if (expressionAnim.IsPlayingAnimationNames("Okay")) return;
             expressionAnim.Play("NoExpression", 0, 0);
         }
 

--- a/Assets/Scripts/Games/TossBoys/TossKid.cs
+++ b/Assets/Scripts/Games/TossBoys/TossKid.cs
@@ -30,7 +30,7 @@ namespace HeavenStudio.Games.Scripts_TossBoys
                 spawnedEffect.Play();
                 DoAnimationScaledAsync(crouch ? "CrouchHit" : "Hit", 0.5f);
             }
-            else if (!anim.IsPlayingAnimationName(prefix + "Whiff") && !anim.IsPlayingAnimationName(prefix + "Miss"))
+            else if (!anim.IsPlayingAnimationNames(prefix + "Whiff", prefix + "Miss"))
             {
                 DoAnimationScaledAsync("Whiff", 0.5f);
                 SoundByte.PlayOneShotGame("tossBoys/whiff");
@@ -40,7 +40,7 @@ namespace HeavenStudio.Games.Scripts_TossBoys
 
         public void Bop()
         {
-            if (crouch || preparing || (!anim.IsAnimationNotPlaying() && !anim.IsPlayingAnimationName(prefix + "Idle"))) return;
+            if (crouch || preparing || (!anim.IsAnimationNotPlaying() && !anim.IsPlayingAnimationNames(prefix + "Idle"))) return;
             DoAnimationScaledAsync("Bop", 0.5f);
         }
 

--- a/Assets/Scripts/Games/WorkingDough/WorkingDough.cs
+++ b/Assets/Scripts/Games/WorkingDough/WorkingDough.cs
@@ -312,7 +312,7 @@ namespace HeavenStudio.Games
                     {
                         NPCBallTransporters.GetComponent<Animator>().Play("NPCGoBigMode", 0, 0);
                     }
-                    if (!instance.ballTransporterLeftNPC.GetComponent<Animator>().IsPlayingAnimationName("BallTransporterLeftOpened"))
+                    if (!instance.ballTransporterLeftNPC.GetComponent<Animator>().IsPlayingAnimationNames("BallTransporterLeftOpened"))
                     {
                         instance.ballTransporterLeftNPC.GetComponent<Animator>().Play("BallTransporterLeftOpen", 0, 0);
                         instance.ballTransporterRightNPC.GetComponent<Animator>().Play("BallTransporterRightOpen", 0, 0);

--- a/Assets/Scripts/Util/AnimationHelpers.cs
+++ b/Assets/Scripts/Util/AnimationHelpers.cs
@@ -14,11 +14,12 @@ namespace HeavenStudio.Util
         /// Returns true if animName is currently playing on animator
         /// </summary>
         /// <param name="anim">Animator to check</param>
-        /// <param name="animName">name of animation to look out for</param>
-        public static bool IsPlayingAnimationName(this Animator anim, string animName)
+        /// <param name="animNames">name(s) of animation to look out for</param>
+        public static bool IsPlayingAnimationNames(this Animator anim, params string[] animNames)
         {
             var stateInfo = anim.GetCurrentAnimatorStateInfo(0);
-            return (stateInfo.normalizedTime < stateInfo.speed || stateInfo.loop) && stateInfo.IsName(animName);
+            var isPlaying = Array.Exists(animNames, animName => stateInfo.IsName(animName));
+            return (stateInfo.normalizedTime < stateInfo.speed || stateInfo.loop) && isPlaying;
         }
 
         /// <summary>


### PR DESCRIPTION
non-devs, pay no attention. nothing was added on the front end.

IsPlayingAnimationName() has been changed to IsPlayingAnimationNames(), and instead of taking a string, it takes in params as an array of strings. the method then checks if the current anim state is in that array, and also checks the stuff it was checking for before.

works well, easier to use, and probably more efficient! what's there to hate