### PR TITLE
Fix #537 (Flipper Flop chronology)

### DIFF
--- a/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
+++ b/Assets/Scripts/Games/FlipperFlop/FlipperFlop.cs
@@ -98,7 +98,7 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 0.5f
                 }
             },
-            new List<string>() { "ntr", "keep" },
+            new List<string>() { "rvl", "keep" },
             "rvlseal", "en",
             new List<string>() { "en" }
             );


### PR DESCRIPTION
Should fix #537 by changing the one small thing. It works assuming you don't need to change anything else for these changes (such as a meta file or some other portion that controls it).

There are still other games not sorted at all (at least in the daily builds) but those games seem to be less complete. I hope they are sorted for any releases, though.