### PR TITLE
Fix golden hour time of day settings being labelled "noon"

### DIFF
--- a/Assets/Scripts/Games/AirRally/AirRally.cs
+++ b/Assets/Scripts/Games/AirRally/AirRally.cs
@@ -141,7 +141,7 @@ namespace HeavenStudio.Games.Loaders
                     parameters = new List<Param>()
                     {
                         new Param("start", AirRally.DayNightCycle.Day, "Start Time", "Set the time of day for the start of the event."),
-                        new Param("end", AirRally.DayNightCycle.Noon, "End Time", "Set the time of day for the end of the event."),
+                        new Param("end", AirRally.DayNightCycle.Twilight, "End Time", "Set the time of day for the end of the event."),
                         new Param("ease", EasingFunction.Ease.Linear, "Ease", "Set the easing of the action.")
                     }
                 },
@@ -337,9 +337,9 @@ namespace HeavenStudio.Games
         [SerializeField] private Material bgMat;
         [SerializeField] private Material objectMat;
         [SerializeField] private Material cloudMat;
-        [SerializeField] private Color noonColor;
+        [SerializeField] private Color twilightColor;
         [SerializeField] private Color nightColor;
-        [SerializeField] private Color noonColorCloud;
+        [SerializeField] private Color twilightColorCloud;
         [SerializeField] private Color nightColorCloud;
         private DayNightCycle lastTime = DayNightCycle.Day;
         private DayNightCycle currentTime = DayNightCycle.Day;
@@ -684,20 +684,20 @@ namespace HeavenStudio.Games
             timeEase = ease;
             objectsColorFrom = lastTime switch
             {
-                DayNightCycle.Noon => Color.black,
+                DayNightCycle.Twilight => Color.black,
                 _ => Color.white,
             };
 
             objectsColorTo = currentTime switch
             {
-                DayNightCycle.Noon => Color.black,
+                DayNightCycle.Twilight => Color.black,
                 _ => Color.white,
             };
 
             bgColorFrom = lastTime switch
             {
                 DayNightCycle.Day => Color.white,
-                DayNightCycle.Noon => noonColor,
+                DayNightCycle.Twilight => twilightColor,
                 DayNightCycle.Night => nightColor,
                 _ => throw new System.NotImplementedException()
             };
@@ -705,7 +705,7 @@ namespace HeavenStudio.Games
             bgColorTo = currentTime switch
             {
                 DayNightCycle.Day => Color.white,
-                DayNightCycle.Noon => noonColor,
+                DayNightCycle.Twilight => twilightColor,
                 DayNightCycle.Night => nightColor,
                 _ => throw new System.NotImplementedException()
             };
@@ -713,7 +713,7 @@ namespace HeavenStudio.Games
             cloudColorFrom = lastTime switch
             {
                 DayNightCycle.Day => Color.white,
-                DayNightCycle.Noon => noonColorCloud,
+                DayNightCycle.Twilight => twilightColorCloud,
                 DayNightCycle.Night => nightColorCloud,
                 _ => throw new System.NotImplementedException()
             };
@@ -721,7 +721,7 @@ namespace HeavenStudio.Games
             cloudColorTo = currentTime switch
             {
                 DayNightCycle.Day => Color.white,
-                DayNightCycle.Noon => noonColorCloud,
+                DayNightCycle.Twilight => twilightColorCloud,
                 DayNightCycle.Night => nightColorCloud,
                 _ => throw new System.NotImplementedException()
             };
@@ -759,7 +759,7 @@ namespace HeavenStudio.Games
         public enum DayNightCycle
         {
             Day = 0,
-            Noon = 1,
+            Twilight = 1,
             Night = 2
         }
 

--- a/Assets/Scripts/Games/DoubleDate/DoubleDate.cs
+++ b/Assets/Scripts/Games/DoubleDate/DoubleDate.cs
@@ -79,7 +79,7 @@ namespace HeavenStudio.Games.Loaders
                     defaultLength = 0.5f,
                     parameters = new()
                     {
-                        new("d", DoubleDate.DayTime.Noon, "Time", "Set the time of day.")
+                        new("d", DoubleDate.DayTime.Sunset, "Time", "Set the time of day.")
                     }
                 }
             },
@@ -123,7 +123,7 @@ namespace HeavenStudio.Games
 
         [Header("Variables")]
         [SerializeField] private Color _skyColor;
-        [SerializeField] private Color noonColor;
+        [SerializeField] private Color sunsetColor;
         [SerializeField] private float _animSpeed = 1.25f;
         [SerializeField] public float cloudSpeed;
         [SerializeField] public float cloudDistance;
@@ -192,7 +192,7 @@ namespace HeavenStudio.Games
         public enum DayTime
         {
             Day,
-            Noon
+            Sunset
         }
 
         private void DayTimeCheck(double beat)
@@ -206,9 +206,9 @@ namespace HeavenStudio.Games
 
         public void SetTime(int time)
         {
-            if (time == (int)DayTime.Noon)
+            if (time == (int)DayTime.Sunset)
             {
-                doubleDateCellAnim.SetColor("_Color", noonColor);
+                doubleDateCellAnim.SetColor("_Color", sunsetColor);
                 bgSquare.color = squareColor;
                 bgGradient.sprite = bgLong;
                 return;
@@ -246,7 +246,7 @@ namespace HeavenStudio.Games
         {
             instance = this;
             SetupBopRegion("doubleDate", "bop", "autoBop");
-            doubleDateCellAnim.SetColor("_Color", noonColor);
+            doubleDateCellAnim.SetColor("_Color", sunsetColor);
             squareColor = bgSquare.color;
         }
 


### PR DESCRIPTION
Noon is when the sun is at its peak, bluest sky. The 'golden hour' happens at sunrise or sunset. This PR should make that accurate for Air Rally and Double Date, which both currently have golden skies at 'noon'.

While both of these are sunset and not sunrise in their actual games (Air Rally for some reason skips the sunrise), the fact that there is day and night transitions in Air Rally led me to try and use a word that applies to both sunrise and sunset. For lack of a better one, it's currently called Twilight. However, this can be changed to something better based on how y'all prefer.