### PR TITLE
Upbeat blip length

### DIFF
--- a/Assets/Scripts/Games/MrUpbeat/MrUpbeat.cs
+++ b/Assets/Scripts/Games/MrUpbeat/MrUpbeat.cs
@@ -77,7 +77,7 @@ namespace HeavenStudio.Games.Loaders
                 {
                     function = delegate {
                         var e = eventCaller.currentEntity;
-                        MrUpbeat.instance.BlipEvents(e["letter"], e["shouldGrow"], e["resetBlip"], e["shouldBlip"]);
+                        MrUpbeat.instance.BlipEvents(e["letter"], e["shouldGrow"], e["resetBlip"], e["shouldBlip"], e["blipLength"]);
                     },
                     defaultLength = 0.5f,
                     parameters = new List<Param>()
@@ -86,6 +86,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("shouldGrow", true, "Grow Antenna", "Toggle if Mr. Upbeat's antennashould grow on every blip"),
                         new Param("resetBlip", false, "Reset Antenna", "Toggle if Mr. Upbeat's antenna should reset"),
                         new Param("shouldBlip", true, "Should Blip", "Toggle if Mr. Upbeat's antenna should blip every offbeat."),
+                        new Param("blipLength", new EntityTypes.Integer(0, 4, 4), "Blip How Many Times", "placeholder"),
                     }
                 },
                 new GameAction("fourBeatCountInOffbeat", "4 Beat Count-In")
@@ -356,12 +357,13 @@ namespace HeavenStudio.Games
             }
         }
 
-        public void BlipEvents(string inputLetter, bool shouldGrow, bool resetBlip, bool shouldBlip)
+        public void BlipEvents(string inputLetter, bool shouldGrow, bool resetBlip, bool shouldBlip, int blipLength)
         {
             if (resetBlip) man.blipSize = 0;
             man.shouldGrow = shouldGrow;
             man.blipString = inputLetter;
             man.shouldBlip = shouldBlip;
+            man.blipLength = blipLength;
         }
 
         public static void Count(int number)

--- a/Assets/Scripts/Games/MrUpbeat/MrUpbeat.cs
+++ b/Assets/Scripts/Games/MrUpbeat/MrUpbeat.cs
@@ -86,7 +86,7 @@ namespace HeavenStudio.Games.Loaders
                         new Param("shouldGrow", true, "Grow Antenna", "Toggle if Mr. Upbeat's antennashould grow on every blip"),
                         new Param("resetBlip", false, "Reset Antenna", "Toggle if Mr. Upbeat's antenna should reset"),
                         new Param("shouldBlip", true, "Should Blip", "Toggle if Mr. Upbeat's antenna should blip every offbeat."),
-                        new Param("blipLength", new EntityTypes.Integer(0, 4, 4), "Blip How Many Times", "placeholder"),
+                        new Param("blipLength", new EntityTypes.Integer(0, 4, 4), "Text Blip Requirement", "Set how many blips it will take for the text to appear on Mr. Upbeat’s antenna."),
                     }
                 },
                 new GameAction("fourBeatCountInOffbeat", "4 Beat Count-In")

--- a/Assets/Scripts/Games/MrUpbeat/UpbeatMan.cs
+++ b/Assets/Scripts/Games/MrUpbeat/UpbeatMan.cs
@@ -19,6 +19,7 @@ namespace HeavenStudio.Games.Scripts_MrUpbeat
         public bool shouldGrow;
         public bool shouldBlip = true;
         public string blipString = "M";
+        public int blipLength = 4;
         public bool canStep = false; // just disabled when you normally couldn't step, which is anything less than 2 beats before you would start stepping and any time after the Ding!
         public bool canStepFromAnim = true; // disabled when stepping, then reenabled in the animation events. you can step JUST BARELY before the animation ends in fever
 
@@ -57,12 +58,13 @@ namespace HeavenStudio.Games.Scripts_MrUpbeat
 
         public void Blipping()
         {
+            int blipLengthReal = blipLength - 4;
             SoundByte.PlayOneShotGame("mrUpbeat/blip");
-            blipAnim.Play("Blip" + (blipSize + 1), 0, 0);
-            blipText.gameObject.SetActive(blipSize >= 4);
+            blipAnim.Play("Blip" + (blipSize + 1 - blipLengthReal), 0, 0);
+            blipText.gameObject.SetActive(blipSize - blipLengthReal >= 4);
             
             blipText.text = blipString != "" ? blipString : "";
-            if (shouldGrow && blipSize < 4) blipSize++;
+            if (shouldGrow && blipSize - blipLengthReal < 4) blipSize++;
         }
 
         public void Step(bool isInput = false)


### PR DESCRIPTION
Now you can choose how many blips it takes before the text appears on mr upbeat's dumb forehead instead of being locked to 4 beats