### PR TITLE
Fix Rockers pitch bend

### DIFF
--- a/Assets/Scripts/Games/Rockers/RockersRocker.cs
+++ b/Assets/Scripts/Games/Rockers/RockersRocker.cs
@@ -220,9 +220,8 @@ namespace HeavenStudio.Games.Scripts_Rockers
             if (bending || !strumming) return;
             bending = true;
             lastBendPitch = pitch;
-            if (chordSound != null)
-            {
-                chordSound.BendUp(0.05f, SoundByte.GetPitchFromSemiTones(SoundByte.GetSemitonesFromPitch(chordSound.pitch, true) + pitch, true));
+            if (chordSound != null) {
+                chordSound.BendUp(0.05f, GetBentPitch(chordSound.pitch, pitch));
             }
             else
             {
@@ -230,7 +229,7 @@ namespace HeavenStudio.Games.Scripts_Rockers
                 {
                     if (stringSounds[i] != null)
                     {
-                        stringSounds[i].BendUp(0.05f, SoundByte.GetPitchFromSemiTones(SoundByte.GetSemitonesFromPitch(stringSounds[i].pitch, true) + pitch, true));
+                        stringSounds[i].BendUp(0.05f, GetBentPitch(stringSounds[i].pitch, pitch));
                     }
                 }
             }
@@ -298,6 +297,14 @@ namespace HeavenStudio.Games.Scripts_Rockers
         private void DoScaledAnimationAsync(string name, float time)
         {
             anim.DoScaledAnimationAsync((JJ ? "JJ" : "") + name, time);
+        }
+        
+        private float GetBentPitch(float pitch, int bend)
+        {
+            float unscaledPitch = chordSound.pitch / Conductor.instance.musicSource.pitch;
+            float bendPitch = SoundByte.GetPitchFromSemiTones(bend, false);
+            
+            return (unscaledPitch * bendPitch) * Conductor.instance.musicSource.pitch;
         }
     }
 }


### PR DESCRIPTION
This fixes a couple bugs with the rockers pitch bend being inaccurate, especially at different playback speeds.

One thing to note is that this could make older remixes using the pitch bend sound weird because I noticed that inputted semitones in older versions would sometimes be inaccurate:

https://github.com/RHeavenStudio/HeavenStudio/assets/62869918/eead29c9-ece1-462b-aa6e-c19480758f7d

In this clip the bend should be going from C# to F# by bending +5 semitones, but it only sounds correct when bending +4 semitones, this is fixed with this commit though. I don't know what the best solution for this would be to avoid confusing players, but I just wanted to make sure to point it out here.